### PR TITLE
Scan builds' code for SequenceR training data

### DIFF
--- a/repairnator/repairnator-core/src/main/java/fr/inria/jtravis/entities/v2/BuildV2.java
+++ b/repairnator/repairnator-core/src/main/java/fr/inria/jtravis/entities/v2/BuildV2.java
@@ -8,37 +8,37 @@ import fr.inria.jtravis.entities.Commit;
 import fr.inria.jtravis.entities.Entity;
 
 public final class BuildV2 extends Entity {
-	
-	@Expose
+
+    @Expose
     private Commit commit;
-	
-	@Expose
-	private String id;
 
-	public String getId() {
-		return id;
-	}
+    @Expose
+    private String id;
 
-	public void setId(String id) {
-		this.id = id;
-	}
+    public String getId() {
+        return id;
+    }
+    
+    public void setId(String id) {
+        this.id = id;
+    }
 
-	public Commit getCommit() {
-		return commit;
-	}
+    public Commit getCommit() {
+        return commit;
+    }
 
-	public void setCommit(Commit commit) {
-		this.commit = commit;
-	}
-	
-	
-	 @Override
-	    public boolean equals(Object o) {
-	        if (this == o) return true;
-	        if (o == null || getClass() != o.getClass()) return false;
-	        final BuildV2 buildV2 = (BuildV2) o;
-	        return commit.equals(buildV2.commit)&& id == buildV2.id;
-	    }
+    public void setCommit(Commit commit) {
+        this.commit = commit;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final BuildV2 buildV2 = (BuildV2) o;
+        return commit.equals(buildV2.commit)&& id == buildV2.id;
+    }
 
     @Override
     public int hashCode() {
@@ -49,14 +49,14 @@ public final class BuildV2 extends Entity {
     @Override
     public String toString() {
         return "JobV2{" +
-                "=" + id +
+                "id=" + id +
                 ", commit=" + commit +
                 '}';
     }
 
-	@Override
-	protected void dispatchJTravisToChildren() {
-		//FIX protected commit.setJtravis() not in same package
-		return;
-	}
+    @Override
+    protected void dispatchJTravisToChildren() {
+        //FIX protected commit.setJtravis() not in same package
+        return;
+    }
 }

--- a/repairnator/repairnator-core/src/main/java/fr/inria/jtravis/entities/v2/BuildV2.java
+++ b/repairnator/repairnator-core/src/main/java/fr/inria/jtravis/entities/v2/BuildV2.java
@@ -1,0 +1,62 @@
+package fr.inria.jtravis.entities.v2;
+
+import java.util.Objects;
+
+import com.google.gson.annotations.Expose;
+
+import fr.inria.jtravis.entities.Commit;
+import fr.inria.jtravis.entities.Entity;
+
+public final class BuildV2 extends Entity {
+	
+	@Expose
+    private Commit commit;
+	
+	@Expose
+	private String id;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public Commit getCommit() {
+		return commit;
+	}
+
+	public void setCommit(Commit commit) {
+		this.commit = commit;
+	}
+	
+	
+	 @Override
+	    public boolean equals(Object o) {
+	        if (this == o) return true;
+	        if (o == null || getClass() != o.getClass()) return false;
+	        final BuildV2 buildV2 = (BuildV2) o;
+	        return commit.equals(buildV2.commit)&& id == buildV2.id;
+	    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(commit, id);
+    }
+
+    @Override
+    public String toString() {
+        return "JobV2{" +
+                "=" + id +
+                ", commit=" + commit +
+                '}';
+    }
+
+	@Override
+	protected void dispatchJTravisToChildren() {
+		//FIX protected commit.setJtravis() not in same package
+		return;
+	}
+}

--- a/repairnator/repairnator-core/src/main/java/fr/inria/jtravis/entities/v2/JobV2.java
+++ b/repairnator/repairnator-core/src/main/java/fr/inria/jtravis/entities/v2/JobV2.java
@@ -18,9 +18,9 @@ public final class JobV2 {
     private int buildId;
     
     @Expose
-    private int commitId;	
+    private int commitId;
 
-	@Expose
+    @Expose
     private String number;
 
     @Expose
@@ -32,11 +32,11 @@ public final class JobV2 {
     @Expose
     private String repositorySlug;
 
-	public String getRepositorySlug() {
-		return repositorySlug;
-	}
+    public String getRepositorySlug() {
+        return repositorySlug;
+    }
 
-	public int getId() {
+    public int getId() {
         return id;
     }
 
@@ -45,8 +45,8 @@ public final class JobV2 {
     }
     
     public int getCommitId() {
-		return commitId;
-	}
+        return commitId;
+    }
 
     public String getNumber() {
         return number;
@@ -65,8 +65,8 @@ public final class JobV2 {
     }
     
     public void setRepositorySlug(String repositorySlug) {
-		this.repositorySlug = repositorySlug;
-	}
+        this.repositorySlug = repositorySlug;
+    }
     
     protected void setId(int id) {
         this.id = id;
@@ -77,8 +77,8 @@ public final class JobV2 {
     }
     
     public void setCommitId(int commitId) {
-		this.commitId = commitId;
-	}
+        this.commitId = commitId;
+    }
 
     protected void setNumber(String number) {
         this.number = number;

--- a/repairnator/repairnator-core/src/main/java/fr/inria/jtravis/entities/v2/JobV2.java
+++ b/repairnator/repairnator-core/src/main/java/fr/inria/jtravis/entities/v2/JobV2.java
@@ -16,8 +16,11 @@ public final class JobV2 {
 
     @Expose
     private int buildId;
-
+    
     @Expose
+    private int commitId;	
+
+	@Expose
     private String number;
 
     @Expose
@@ -25,14 +28,25 @@ public final class JobV2 {
 
     @Expose
     private Config config;
+    
+    @Expose
+    private String repositorySlug;
 
-    public int getId() {
+	public String getRepositorySlug() {
+		return repositorySlug;
+	}
+
+	public int getId() {
         return id;
     }
 
     public int getRepositoryId() {
         return repositoryId;
     }
+    
+    public int getCommitId() {
+		return commitId;
+	}
 
     public String getNumber() {
         return number;
@@ -49,7 +63,11 @@ public final class JobV2 {
     public int getBuildId() {
         return buildId;
     }
-
+    
+    public void setRepositorySlug(String repositorySlug) {
+		this.repositorySlug = repositorySlug;
+	}
+    
     protected void setId(int id) {
         this.id = id;
     }
@@ -57,6 +75,10 @@ public final class JobV2 {
     protected void setRepositoryId(int repositoryId) {
         this.repositoryId = repositoryId;
     }
+    
+    public void setCommitId(int commitId) {
+		this.commitId = commitId;
+	}
 
     protected void setNumber(String number) {
         this.number = number;

--- a/repairnator/repairnator-realtime/pom.xml
+++ b/repairnator/repairnator-realtime/pom.xml
@@ -65,6 +65,7 @@
                     <encoding>${default.encoding}</encoding>
                 </configuration>
             </plugin>
+            
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/BuildHelperV2.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/BuildHelperV2.java
@@ -1,0 +1,31 @@
+package fr.inria.spirals.repairnator.realtime;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Properties;
+
+import fr.inria.jtravis.JTravis;
+import fr.inria.jtravis.TravisConstants;
+import fr.inria.jtravis.entities.v2.BuildV2;
+import fr.inria.jtravis.helpers.BuildHelper;
+
+
+// The motivation of this class is that currently the Travis API is returning inconsistent
+// date formats when requesting a build. Therefore this helper and corresponding entity
+// excludes all attributes that are not needed for the current purpose.
+public class BuildHelperV2 extends BuildHelper {
+
+	public BuildHelperV2(JTravis jtravis) {
+		super(jtravis);
+	}
+	
+	
+	public Optional<BuildV2> fromIdV2(long id) {
+		 Properties properties = new Properties();
+	        properties.put("include","job.config");
+
+	        return super.getEntityFromUri(BuildV2.class, Arrays.asList(TravisConstants.BUILD_ENDPOINT, String.valueOf(id)), properties);
+	    
+	}
+	
+}

--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/BuildHelperV2.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/BuildHelperV2.java
@@ -10,9 +10,10 @@ import fr.inria.jtravis.entities.v2.BuildV2;
 import fr.inria.jtravis.helpers.BuildHelper;
 
 
-// The motivation of this class is that currently the Travis API is returning inconsistent
-// date formats when requesting a build. Therefore this helper and corresponding entity
-// excludes all attributes that are not needed for the current purpose.
+/** The motivation of this class is that currently the Travis API is returning inconsistent
+ * date formats when requesting a build. Therefore this helper and corresponding entity
+ * excludes all attributes that are not needed for the current purpose.
+ */
 public class BuildHelperV2 extends BuildHelper {
 
 	public BuildHelperV2(JTravis jtravis) {

--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/FastScanner.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/FastScanner.java
@@ -46,7 +46,6 @@ public class FastScanner implements Runnable {
         int nInteresting = 0;
         Set<Long> done = new HashSet<>();
         JobHelperv2 jobHelperv2 = new JobHelperv2(RepairnatorConfig.getInstance().getJTravis());
-        SequencerCollector collector = new SequencerCollector();
         while (true) {
             try {
                 Optional<List<JobV2>> jobListOpt = jobHelperv2.allFromV2();
@@ -70,11 +69,8 @@ public class FastScanner implements Runnable {
                             System.out.println("=====" + job.getId() + " " +job.getBuildId());
                             done.add((long)job.getBuildId());
 
-//                            Optional<Build> optionalBuild = RepairnatorConfig.getInstance().getJTravis().build().fromId(job.getBuildId());
-//                            FastScanner.this.rtScanner.submitBuildToExecution(optionalBuild.get());
-                        } else if ("java".equals(job.getConfig().getLanguage()) && StateType.PASSED.equals(job.getState()) && ! done.contains(job.getBuildId())) {
-                        	System.out.println("==Job id " +  job.getId() + "====Job Commit ID -> " + job.getCommitId()  + "=== Slug: " + job.getRepositorySlug());
-                        	collector.add(job);                  
+                            Optional<Build> optionalBuild = RepairnatorConfig.getInstance().getJTravis().build().fromId(job.getBuildId());
+                            FastScanner.this.rtScanner.submitBuildToExecution(optionalBuild.get());
                         }
                     }
                 }

--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/FastScanner.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/FastScanner.java
@@ -46,6 +46,7 @@ public class FastScanner implements Runnable {
         int nInteresting = 0;
         Set<Long> done = new HashSet<>();
         JobHelperv2 jobHelperv2 = new JobHelperv2(RepairnatorConfig.getInstance().getJTravis());
+        SequencerCollector collector = new SequencerCollector();
         while (true) {
             try {
                 Optional<List<JobV2>> jobListOpt = jobHelperv2.allFromV2();
@@ -71,6 +72,9 @@ public class FastScanner implements Runnable {
 
                             Optional<Build> optionalBuild = RepairnatorConfig.getInstance().getJTravis().build().fromId(job.getBuildId());
                             FastScanner.this.rtScanner.submitBuildToExecution(optionalBuild.get());
+                        } else if ("java".equals(job.getConfig().getLanguage()) && StateType.PASSED.equals(job.getState()) && ! done.contains(job.getBuildId())) {
+                        	System.out.println("==Job id " +  job.getId() + "====Job Commit ID -> " + job.getCommitId()  + "=== Slug: " + job.getRepositorySlug());
+                        	collector.add(job);                  
                         }
                     }
                 }

--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/FastScanner.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/FastScanner.java
@@ -70,8 +70,8 @@ public class FastScanner implements Runnable {
                             System.out.println("=====" + job.getId() + " " +job.getBuildId());
                             done.add((long)job.getBuildId());
 
-                            Optional<Build> optionalBuild = RepairnatorConfig.getInstance().getJTravis().build().fromId(job.getBuildId());
-                            FastScanner.this.rtScanner.submitBuildToExecution(optionalBuild.get());
+//                            Optional<Build> optionalBuild = RepairnatorConfig.getInstance().getJTravis().build().fromId(job.getBuildId());
+//                            FastScanner.this.rtScanner.submitBuildToExecution(optionalBuild.get());
                         } else if ("java".equals(job.getConfig().getLanguage()) && StateType.PASSED.equals(job.getState()) && ! done.contains(job.getBuildId())) {
                         	System.out.println("==Job id " +  job.getId() + "====Job Commit ID -> " + job.getCommitId()  + "=== Slug: " + job.getRepositorySlug());
                         	collector.add(job);                  

--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/JobHelperv2.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/JobHelperv2.java
@@ -57,7 +57,7 @@ class JobHelperv2 extends JobHelper {
         String response = this.get(url, API_VERSION.v2, 2);
         JsonObject jsonObj = getJsonFromStringContent(response);
         JsonArray jsonArray = jsonObj.getAsJsonArray("jobs");
-        List<JobV2> result = new ArrayList();
+        List<JobV2> result = new ArrayList<JobV2>();
         Iterator var6 = jsonArray.iterator();
 
         while (var6.hasNext()) {
@@ -84,7 +84,7 @@ class JobHelperv2 extends JobHelper {
         String response = this.get(url, API_VERSION.v2, 2);
         JsonObject jsonObj = getJsonFromStringContent(response);
         JsonArray jsonArray = jsonObj.getAsJsonArray("builds");
-        List<Build> result = new ArrayList();
+        List<Build> result = new ArrayList<Build>();
         Iterator var6 = jsonArray.iterator();
 
         while (var6.hasNext()) {

--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerCollector.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerCollector.java
@@ -1,0 +1,58 @@
+package fr.inria.spirals.repairnator.realtime;
+
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Vector;
+
+import org.eclipse.egit.github.core.Commit;
+import org.eclipse.egit.github.core.CommitFile;
+import org.eclipse.egit.github.core.client.*;
+
+import fr.inria.jtravis.helpers.BuildHelper;
+import fr.inria.jtravis.entities.Build;
+import fr.inria.jtravis.entities.v2.JobV2;
+import fr.inria.spirals.repairnator.config.RepairnatorConfig;
+
+public class SequencerCollector {
+	
+	private Vector<String> data;
+	private BuildHelper buildHelper;
+	private GitHubClient gitHubClient;
+	
+	public SequencerCollector() {
+		buildHelper = RepairnatorConfig.getInstance().getJTravis().build();
+		data = new Vector<String>();
+	}
+	
+	public void add(JobV2 job) {
+		data.add(getDiff(job));
+	}
+	
+	private String getDiff(JobV2 job) {
+		System.out.println(job.getBuildId());
+		Optional<Build> build = buildHelper.fromId(job.getBuildId());
+		if(!build.isPresent()) {
+			return "no diff"; //TODO: handle this properly.
+		}
+		String sha = build.get().getCommit().getSha();
+		
+		gitHubClient = new GitHubClient();
+		
+		GitHubRequest req = new GitHubRequest();
+		req.setUri("/repos/" + job.getRepositorySlug() + "/commits/" + sha);
+		
+		GitHubResponse resp;
+		
+		 try {
+			resp = gitHubClient.get(req);
+		} catch (IOException e) {
+			return "no diff - error"; //TODO: handle this properly
+		}
+		
+		Commit commit = (Commit)resp.getBody();
+		
+		return "the diff";
+	}
+	
+}

--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerCollector.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerCollector.java
@@ -13,6 +13,10 @@ import fr.inria.spirals.repairnator.config.RepairnatorConfig;
 
 import org.kohsuke.github.*;
 
+
+/**
+ * Filters and stores data for Sequencer training.
+ * */
 public class SequencerCollector {
 	
 	private Vector<String> data;
@@ -23,7 +27,7 @@ public class SequencerCollector {
 		buildHelper = new BuildHelperV2(RepairnatorConfig.getInstance().getJTravis());
 		data = new Vector<String>();
 		try {
-			github = GitHub.connectAnonymously();
+			github = GitHub.connect(); //TODO: descriptive documentation about(or link to) .github file
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -31,15 +35,14 @@ public class SequencerCollector {
 		
 	}
 	
-	public void add(JobV2 job) {
+	public void handle(JobV2 job) {
 		String diff = getDiff(job);
 		data.add(diff);
 		
-		System.out.println(diff);
+		//System.out.println(diff);
 	}
 	
 	private String getDiff(JobV2 job) {
-		System.out.println(job.getBuildId());
 		Optional<BuildV2> build = buildHelper.fromIdV2(job.getBuildId());
 		if(!build.isPresent()) {
 			return "no diff - cannot find build"; //TODO: handle this properly.
@@ -54,7 +57,7 @@ public class SequencerCollector {
 			
 			List<GHCommit.File> files = commit.getFiles(); 
 			
-			if(files.size() == 1) {
+			if(files.size() == 1 && files.get(0).getFileName().endsWith(".java")) {
 				System.out.println("Patch: " + files.get(0).getPatch() );
 				return "single-file diff";	
 			}

--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerCollector.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerCollector.java
@@ -1,15 +1,19 @@
 package fr.inria.spirals.repairnator.realtime;
 
 
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.Vector;
-
 
 import fr.inria.jtravis.entities.v2.BuildV2;
 import fr.inria.jtravis.entities.v2.JobV2;
 import fr.inria.spirals.repairnator.config.RepairnatorConfig;
+import fr.inria.spirals.repairnator.realtime.utils.PatchFilter;
+import fr.inria.spirals.repairnator.realtime.utils.PatchFilter.PatchLines;
 
 import org.kohsuke.github.*;
 
@@ -18,34 +22,31 @@ import org.kohsuke.github.*;
  * Filters and stores data for Sequencer training.
  * */
 public class SequencerCollector {
-	
-	private Vector<String> data;
+    
+    //TODO: find a temporary storage solution.
+    private final String addedFilename = System.getProperty("user.home") + "/added.txt";
+    private final String removedFilename = System.getProperty("user.home") + "/removed.txt";
+
 	private BuildHelperV2 buildHelper;
-	GitHub github;
+	private GitHub github;
+	private PatchFilter filter;
 	
 	public SequencerCollector() {
 		buildHelper = new BuildHelperV2(RepairnatorConfig.getInstance().getJTravis());
-		data = new Vector<String>();
 		try {
 			github = GitHub.connect(); //TODO: descriptive documentation about(or link to) .github file
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-		
+		filter = new PatchFilter();
 	}
+	
 	
 	public void handle(JobV2 job) {
-		String diff = getDiff(job);
-		data.add(diff);
-		
-		//System.out.println(diff);
-	}
-	
-	private String getDiff(JobV2 job) {
 		Optional<BuildV2> build = buildHelper.fromIdV2(job.getBuildId());
 		if(!build.isPresent()) {
-			return "no diff - cannot find build"; //TODO: handle this properly.
+			return; // no diff - cannot find build.
 		}
 		String sha = build.get().getCommit().getSha();
 	
@@ -57,16 +58,38 @@ public class SequencerCollector {
 			
 			List<GHCommit.File> files = commit.getFiles(); 
 			
-			if(files.size() == 1 && files.get(0).getFileName().endsWith(".java")) {
-				System.out.println("Patch: " + files.get(0).getPatch() );
-				return "single-file diff";	
+			if(files.size() != 1 || !files.get(0).getFileName().endsWith(".java")) {
+			    return;// multi-file diff
 			}
 			
-			return "multi-file diff";
+			String patch = files.get(0).getPatch();
+				
+			if (!filter.test(patch)) {
+			    return; // multi-hunk or multi-line patch	   
+			}
+			
+			System.out.println("Found:");
+			System.out.println(patch);
+			
+			PatchLines lines = filter.parse(patch);
+			
+			FileWriter addedFileWriter = new FileWriter(addedFilename, true);
+		    PrintWriter addedPrintWriter = new PrintWriter(addedFileWriter, true);
+		    
+		    addedPrintWriter.println(lines.added);
+		    addedPrintWriter.close();
+		    
+		    FileWriter removedFileWriter = new FileWriter(removedFilename, true);
+            PrintWriter removedPrintWriter = new PrintWriter(removedFileWriter, true);
+            
+            removedPrintWriter.println(lines.removed);
+            removedPrintWriter.close();
+			
+			
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
-			return "error";
+			return;// "error";
 		}
 		
 	}

--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerLearnerScanner.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerLearnerScanner.java
@@ -1,0 +1,55 @@
+package fr.inria.spirals.repairnator.realtime;
+
+import fr.inria.jtravis.entities.StateType;
+import fr.inria.jtravis.entities.v2.JobV2;
+import fr.inria.spirals.repairnator.config.RepairnatorConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Scanner based on FastScanner.java but re-purposed for scanning for Sequencer training data.
+ */
+public class SequencerLearnerScanner implements Runnable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SequencerLearnerScanner.class);
+
+    public static void main(String[] args) {
+        new SequencerLearnerScanner().run();
+        
+    }
+
+    @Override
+    public void run() {
+        LOGGER.debug("Start running inspect Jobs...");
+        JobHelperv2 jobHelperv2 = new JobHelperv2(RepairnatorConfig.getInstance().getJTravis());
+        SequencerCollector collector = new SequencerCollector();
+        
+        final int scanBackIterations = 10;
+        final int jumpSize = 250;
+        
+        while (true) {
+            try {
+                Optional<List<JobV2>> latestJobListOpt = jobHelperv2.allFromV2();
+                List<JobV2> latestJobList = latestJobListOpt.get();
+                int latestJobId = latestJobList.get(0).getId();
+            	for (int it = 0; it < scanBackIterations; ++it) {
+            		
+            		List<JobV2> jobList = jobHelperv2.allSubSequentJobsFrom(latestJobId - (it*jumpSize));
+            		for (JobV2 job : jobList) {
+                    	if ("java".equals(job.getConfig().getLanguage()) && StateType.PASSED.equals(job.getState())) {
+                        	//System.out.println("==Job id " +  job.getId() + "====Job Commit ID -> " + job.getCommitId()  + "=== Slug: " + job.getRepositorySlug());
+                        	collector.handle(job);                  
+                        }
+                    }
+            	}
+                
+
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        } // end while loop
+    }
+
+}

--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerLearnerScanner.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerLearnerScanner.java
@@ -39,7 +39,6 @@ public class SequencerLearnerScanner implements Runnable {
             		List<JobV2> jobList = jobHelperv2.allSubSequentJobsFrom(latestJobId - (it*jumpSize));
             		for (JobV2 job : jobList) {
                     	if ("java".equals(job.getConfig().getLanguage()) && StateType.PASSED.equals(job.getState())) {
-                        	//System.out.println("==Job id " +  job.getId() + "====Job Commit ID -> " + job.getCommitId()  + "=== Slug: " + job.getRepositorySlug());
                         	collector.handle(job);                  
                         }
                     }

--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/utils/PatchFilter.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/utils/PatchFilter.java
@@ -1,0 +1,112 @@
+package fr.inria.spirals.repairnator.realtime.utils;
+
+
+/**
+ * Single-hunk, single-line-change patch filter.
+ * */
+public class PatchFilter {
+    
+    enum State {
+        ENTRY,
+        HEADER,
+        ENTRY_CONTEXT,
+        EXIT_CONTEXT,
+        REMOVE,
+        ADD
+    }
+    
+    public class PatchLines {
+        public PatchLines(String removed, String added) {
+            this.removed = removed;
+            this.added = added;
+        }
+        
+        public final String removed;
+        public final String added;
+    }
+    
+    public boolean test(String patch) {
+
+        State state = State.ENTRY;
+        String[] lines = patch.split("\n");
+        
+        for(String line : lines) {
+            switch(state) {
+            
+            case ENTRY:
+                //assume first line hunk header
+                state = State.HEADER;
+                break;
+            
+            case HEADER:{
+                char first = line.charAt(0);
+                if(first == '-') {
+                    state = State.REMOVE;
+                } else if(first == ' ') {
+                    state = State.ENTRY_CONTEXT;
+                } else if(first == '+') {
+                    return false;
+                }
+                
+            }break;
+            
+            case ENTRY_CONTEXT:{
+                char first = line.charAt(0);
+                if(first == '-') {
+                    state = State.REMOVE;
+                } else if(first == ' ') {
+                    state = State.ENTRY_CONTEXT;
+                } else {
+                    return false;
+                }
+            }break;
+            
+            case REMOVE:{
+                char first = line.charAt(0);
+                if(first == '+') {
+                    state = State.ADD;
+                }else{
+                    return false;
+                }
+            }break;
+            
+            case ADD:{
+                char first = line.charAt(0);
+                if(first == ' ') {
+                    state = State.EXIT_CONTEXT;
+                }else{
+                    return false;
+                }
+            }break;
+            
+            case EXIT_CONTEXT:{
+                char first = line.charAt(0);
+                if(first == ' ') {
+                    state = State.EXIT_CONTEXT;
+                }else{
+                    return false;
+                }
+            }break;
+            
+            }
+        }
+        
+        
+        return state == State.EXIT_CONTEXT || state == State.ADD;
+    }
+    
+    public PatchLines parse(String patch) {
+        String[] lines = patch.split("\n");
+        
+        String removed= "";
+        String added = "";
+        
+        for(String line : lines) {
+            char first = line.charAt(0);
+            if(first == '-') removed = line.substring(1).trim();
+            if(first == '+') added = line.substring(1).trim();
+        }
+        
+        return new PatchLines(removed, added);
+    }
+}

--- a/repairnator/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/utils/PatchFilterTest.java
+++ b/repairnator/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/utils/PatchFilterTest.java
@@ -1,0 +1,125 @@
+package fr.inria.spirals.repairnator.realtime.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class PatchFilterTest {
+
+    
+    @Test
+    public void correctSingleLinePatch() {
+        PatchFilter filter = new PatchFilter();
+        
+        String patch = "@@ -39,8 +42,9 @@ public void testActiveMQSubmitter()\n"
+                     + " \n"
+                     + " ActiveMQBuildSubmitter submitter = new ActiveMQBuildSubmitter();\n"
+                     + " submitter.initBroker();\n"
+                     + "-submitter.submit(\"Test\");\n"
+                     + "+submitter.submit(\"WrongTest\");\n"
+                     + " assertEquals(submitter.receiveFromQueue(),\"Test\");\n"
+                     + " submitter.submitBuild(config.getInstance().getJTravis().build().fromId(589911671).get());\n";
+      
+        assertTrue(filter.test(patch));
+    }
+    
+    @Test
+    public void correctSingleLinePatchNoContext() {
+        PatchFilter filter = new PatchFilter();
+        
+        String patch = "@@ -39,8 +42,9 @@ public void testActiveMQSubmitter()\n"
+                     + "-submitter.submit(\"Test\");\n"
+                     + "+submitter.submit(\"WrongTest\");\n";
+        assertTrue(filter.test(patch));
+    }
+    
+    @Test
+    public void incorrectMultiLinePatch1() {
+        PatchFilter filter = new PatchFilter();
+        
+        String patch = "@@ -39,8 +42,9 @@ public void testActiveMQSubmitter()\n"
+                     + " \n"
+                     + " ActiveMQBuildSubmitter submitter = new ActiveMQBuildSubmitter();\n"
+                     + "-submitter.initBroker();\n"
+                     + "-submitter.submit(\"Test\");\n"
+                     + "+submitter.submit(\"WrongTest\");\n"
+                     + "+assertEquals(submitter.receiveFromQueue(),\"Test\");\n"
+                     + " submitter.submitBuild(config.getInstance().getJTravis().build().fromId(589911671).get());\n";
+      
+        assertFalse(filter.test(patch));
+    }
+    
+    @Test
+    public void incorrectMultiLinePatch2() {
+        PatchFilter filter = new PatchFilter();
+        
+        String patch = "@@ -39,8 +42,9 @@ public void testActiveMQSubmitter()\n"
+                     + " \n"
+                     + " ActiveMQBuildSubmitter submitter = new ActiveMQBuildSubmitter();\n"
+                     + " submitter.initBroker();\n"
+                     + "-submitter.submit(\"Test\");\n"
+                     + "+submitter.submit(\"WrongTest\");\n"
+                     + "+assertEquals(submitter.receiveFromQueue(),\"Test\");\n"
+                     + " submitter.submitBuild(config.getInstance().getJTravis().build().fromId(589911671).get());\n";
+      
+        assertFalse(filter.test(patch));
+    }
+    
+    @Test
+    public void incorrectMultiLinePatch3() {
+        PatchFilter filter = new PatchFilter();
+        
+        String patch = "@@ -39,8 +42,9 @@ public void testActiveMQSubmitter()\n"
+                     + " \n"
+                     + "-ActiveMQBuildSubmitter submitter = new ActiveMQBuildSubmitter();\n"
+                     + "+submitter.initBroker();\n"
+                     + " submitter.submit(\"Test\");\n"
+                     + "-submitter.submit(\"WrongTest\");\n"
+                     + "+assertEquals(submitter.receiveFromQueue(),\"Test\");\n"
+                     + " submitter.submitBuild(config.getInstance().getJTravis().build().fromId(589911671).get());\n";
+      
+        assertFalse(filter.test(patch));
+    }
+    
+    @Test
+    public void incorrectMultiHunkPatch() {
+        PatchFilter filter = new PatchFilter();
+        
+        String patch = "@@ -39,8 +42,9 @@ public void testActiveMQSubmitter()\n"
+                     + " \n"
+                     + "-ActiveMQBuildSubmitter submitter = new ActiveMQBuildSubmitter();\n"
+                     + "+submitter.initBroker();\n"
+                     + " submitter.submit(\"Test\");\n"
+                     + " submitter.submit(\"WrongTest\");\n"
+                     + " assertEquals(submitter.receiveFromQueue(),\"Test\");\n"
+                     + "@@ -139,8 +142,9 @@ public void testActiveMQSubmitter()\n"
+                     + " \n"
+                     + "-ActiveMQBuildSubmitter submitter = new ActiveMQBuildSubmitter();\n"
+                     + "+submitter.initBroker();\n"
+                     + " submitter.submit(\"Test\");\n"
+                     + " submitter.submitBuild(config.getInstance().getJTravis().build().fromId(589911671).get());\n";
+      
+        assertFalse(filter.test(patch));
+    }
+    
+    @Test
+    public void correctParse() {
+        PatchFilter filter = new PatchFilter();
+        
+        String patch = "@@ -39,8 +42,9 @@ public void testActiveMQSubmitter()\n"
+                     + " \n"
+                     + " ActiveMQBuildSubmitter submitter = new ActiveMQBuildSubmitter();\n"
+                     + " submitter.initBroker();\n"
+                     + "-submitter.submit(\"Test\");\n"
+                     + "+submitter.submit(\"WrongTest\");\n"
+                     + " assertEquals(submitter.receiveFromQueue(),\"Test\");\n"
+                     + " submitter.submitBuild(config.getInstance().getJTravis().build().fromId(589911671).get());\n";
+      
+        PatchFilter.PatchLines lines = filter.parse(patch);
+        
+        assertEquals("submitter.submit(\"Test\");", lines.removed);
+        assertEquals("submitter.submit(\"WrongTest\");", lines.added);
+    }
+}


### PR DESCRIPTION
## Description

The `SequencerLearnerScanner` class is based on `FastScanner`, but re purposed to fetch passing builds and process them using `SequencerCollector`.

SequencerCollector will be responsible for fetching and scanning all passing builds' commits for compatible [SequenceR](https://github.com/KTH/sequencer) training data.

## Current Status

Passing java builds' commits are being retrieved from GitHub, the current filter checks for:
- Single-file commits
- File to actually be a .java file

## Next Steps
- Filter out test files
- Implement filter to only allow single-line fixes.
  - filter out patches with several points of modification (scan for multiple `@@` lines)
  - scan for pattern `-[line] \n +[line]` and validate that it is not a block change boundary. Use regex(?)
- Deal with data storage and tokenization(?)

## Problems
- Currently the TravisCI API is returning build information with inconsistent date formats as described [here](https://travis-ci.community/t/api-v3-build-buildid/5479). A work around has been made, but if this is intended behavior, or it is not fixed, it will be necessary to update the JTravis lib to deal directly with this inconsistency. 
UPDATE: TravisCI has responded saying that it _looks like_ a bug and that they will check on it _soon_, so I believe we can use the workaround until they give a more concrete response.