### PR TITLE
Feat: new entry point method for pipeline from Jenkins plugin

### DIFF
--- a/repairnator/repairnator-pipeline/pom.xml
+++ b/repairnator/repairnator-pipeline/pom.xml
@@ -177,3 +177,4 @@
         </plugins>
     </build>
 </project>
+ 

--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/Launcher.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/Launcher.java
@@ -4,8 +4,6 @@ import static fr.inria.spirals.repairnator.config.RepairnatorConfig.LISTENER_MOD
 import java.lang.reflect.Constructor;
 import fr.inria.spirals.repairnator.Listener;
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.BasicConfigurator;
-import ch.qos.logback.classic.LoggerContext;
 import com.martiansoftware.jsap.FlaggedOption;
 import com.martiansoftware.jsap.JSAP;
 import com.martiansoftware.jsap.JSAPException;
@@ -506,12 +504,8 @@ public class Launcher {
     }
 
     public static void main(String[] args) throws JSAPException {
-        /*System.out.println("Jar installed locally - HENRY");*/
-        /*Launcher launcher = new Launcher(args);
-        initProcess(launcher);*/
-
-        Launcher launcher = new Launcher();
-        launcher.jenkinsMain(625844453);
+        Launcher launcher = new Launcher(args);
+        initProcess(launcher);
     }
 
     public ProjectInspector getInspector() {


### PR DESCRIPTION
Issue (#469)

Hi @monperrus :) , This is a introduce a new entry point for the pipeline to be used by Jenkins plugin . It skip JSAP since it causes some errors and we don't really need JSAP if we use the plugin. I need this released to Sonatype later so I can import it as a maven dependency for our plugin.