### PR TITLE
fix: does not output GitHub Token in logs

### DIFF
--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/maven/output/MavenOutputHandler.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/maven/output/MavenOutputHandler.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.regex.Pattern;
 
 /**
  * Created by urli on 15/02/2017.
@@ -45,8 +46,13 @@ public abstract class MavenOutputHandler implements InvocationOutputHandler {
     }
 
     private void writeToFile(String s) {
+    	String githubToken = "GITHUB_TOKEN=[a-zA-Z0-9]+";
+    	String confidentialInformation = "GITHUB_TOKEN=CONFIDENTIAL_INFORMATION";
         if (this.fileWriter != null) {
             try {
+            	if (Pattern.compile(githubToken).matcher(s).find()) {
+            		s = s.replaceAll(githubToken, confidentialInformation);
+            	}
                 this.fileWriter.write(s);
                 this.fileWriter.flush();
             } catch (IOException e) {

--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/maven/output/MavenOutputHandler.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/maven/output/MavenOutputHandler.java
@@ -50,7 +50,7 @@ public abstract class MavenOutputHandler implements InvocationOutputHandler {
     	String confidentialInformation = "CONFIDENTIAL_INFORMATION";
         if (this.fileWriter != null) {
             try {
-            	if (s.contains(githubToken)) {
+            	if (s != null && s.contains(githubToken)) {
             		s = s.replaceAll(githubToken, confidentialInformation);
             	}
                 this.fileWriter.write(s);

--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/maven/output/MavenOutputHandler.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/maven/output/MavenOutputHandler.java
@@ -50,7 +50,7 @@ public abstract class MavenOutputHandler implements InvocationOutputHandler {
     	String confidentialInformation = "CONFIDENTIAL_INFORMATION";
         if (this.fileWriter != null) {
             try {
-            	if (s != null && s.contains(githubToken)) {
+            	if (githubToken != null && s != null && s.contains(githubToken)) {
             		s = s.replaceAll(githubToken, confidentialInformation);
             	}
                 this.fileWriter.write(s);

--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/maven/output/MavenOutputHandler.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/maven/output/MavenOutputHandler.java
@@ -1,5 +1,6 @@
 package fr.inria.spirals.repairnator.process.maven.output;
 
+import fr.inria.spirals.repairnator.config.RepairnatorConfig;
 import fr.inria.spirals.repairnator.process.inspectors.ProjectInspector;
 import fr.inria.spirals.repairnator.process.maven.MavenHelper;
 import org.apache.maven.shared.invoker.InvocationOutputHandler;
@@ -8,7 +9,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.regex.Pattern;
 
 /**
  * Created by urli on 15/02/2017.
@@ -46,11 +46,11 @@ public abstract class MavenOutputHandler implements InvocationOutputHandler {
     }
 
     private void writeToFile(String s) {
-    	String githubToken = "GITHUB_TOKEN=[a-zA-Z0-9]+";
-    	String confidentialInformation = "GITHUB_TOKEN=CONFIDENTIAL_INFORMATION";
+    	String githubToken = RepairnatorConfig.getInstance().getGithubToken();
+    	String confidentialInformation = "CONFIDENTIAL_INFORMATION";
         if (this.fileWriter != null) {
             try {
-            	if (Pattern.compile(githubToken).matcher(s).find()) {
+            	if (s.contains(githubToken)) {
             		s = s.replaceAll(githubToken, confidentialInformation);
             	}
                 this.fileWriter.write(s);


### PR DESCRIPTION
When Repairnator is configured to push the results on an external GitHub repository, the "repairnator.maven.testproject.log" file associated with some builds (e.g., this one: 361311603) contains the GitHub token used by the user. This causes a security problem, GitHub revokes the OAuth token, and thus it is necessary to generate another one every time this situation happens.

The proposed fix replaces the user GitHub Oauth token with the string "CONFIDENTIAL_INFORMATION" before writing it in the .log files.

You can see an example of log file generated with the proposed fix [here](https://github.com/dginelli/test-token-security/blob/tverdokhlebd-mined-in-361311603-20180402-211043/repairnator.maven.testproject.log#L95). The original version of the same file is [this one](https://github.com/dginelli/test-token-security-2/blob/tverdokhlebd-mined-in-361311603-20180402-211043/repairnator.maven.testproject.log#L95).

Signed-off-by: ginellidavide@gmail.com ginellidavide@gmail.com