### PR TITLE
Fix project identifier folders

### DIFF
--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/ProjectInspector.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/ProjectInspector.java
@@ -82,7 +82,7 @@ public class ProjectInspector {
         this.buildToBeInspected = buildToBeInspected;
 
         this.workspace = workspace;
-        this.repoLocalPath = workspace + File.separator + getRepoSlug();
+        this.repoLocalPath = workspace + File.separator + this.buildToBeInspected.getBuggyBuild().getId() + File.separator + getRepoSlug();
         this.repoToPushLocalPath = repoLocalPath+"_topush";
         this.m2LocalPath = new File(this.repoLocalPath + File.separator + ".m2").getAbsolutePath();
         this.serializers = serializers;
@@ -99,7 +99,7 @@ public class ProjectInspector {
         this.gitBranch = gitBranch;
         this.gitSlug = this.gitUrl.split("https://github.com/",2)[1].replace(".git","");
         this.workspace = workspace;
-        this.repoLocalPath = workspace + File.separator + this.gitSlug;
+        this.repoLocalPath = workspace + File.separator + this.buildToBeInspected.getBuggyBuild().getId() + File.separator + this.gitSlug;
         this.repoToPushLocalPath = repoLocalPath+"_topush";
         this.m2LocalPath = new File(this.repoLocalPath + File.separator + ".m2").getAbsolutePath();
         this.serializers = serializers;

--- a/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/astor/AstorRepair.java
+++ b/repairnator/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/astor/AstorRepair.java
@@ -91,6 +91,9 @@ public abstract class AstorRepair extends AbstractRepairStep {
             astorArgs.add("-faultlocalization");
             astorArgs.add("CoCoSpoon");
 
+            astorArgs.add("-id");
+            astorArgs.add(this.getRepairToolName() + "-" + getInspector().getBuggyBuild().getId());
+
             final AstorMain astorMain = new AstorMain();
 
             final String repairToolName = this.getRepairToolName();


### PR DESCRIPTION
Changed the folder names associated with the builds created by Repairnator and Astor in their workspace to avoid conflicts. More details are in the commit messages.