### PR TITLE
feat: Sequencer collector now stores hunks separately

### DIFF
--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerLearnerScanner.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerLearnerScanner.java
@@ -74,7 +74,9 @@ public class SequencerLearnerScanner implements Runnable {
                 
 
             } catch (Exception e) {
-                throw new RuntimeException(e);
+                System.err.println(e.toString());
+                System.err.println("failed to get commit");
+                //throw new RuntimeException(e);
             }
         } // end while loop
     }

--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/utils/SequencerCollectorHunk.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/utils/SequencerCollectorHunk.java
@@ -1,0 +1,26 @@
+package fr.inria.spirals.repairnator.realtime.utils;
+
+public class SequencerCollectorHunk {
+    
+        public SequencerCollectorHunk(int line, String file, String content) {
+            this.line = line;
+            this.file = file;
+            this.content = content;
+        }
+        
+        final int line;
+        final String file;
+        final String content;
+        
+        public String getContent() {
+            return content;
+        }
+        
+        public String getFile() {
+            return file;
+        }
+        
+        public int getLine() {
+            return line;
+        }
+}

--- a/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/utils/SequencerCollectorPatch.java
+++ b/repairnator/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/utils/SequencerCollectorPatch.java
@@ -1,0 +1,19 @@
+package fr.inria.spirals.repairnator.realtime.utils;
+
+public class SequencerCollectorPatch {
+    public SequencerCollectorPatch(String file, String content) {
+        this.file = file;
+        this.content = content;
+    }
+    
+    final String file;
+    final String content;
+    
+    public String getContent() {
+        return content;
+    }
+    
+    public String getFile() {
+        return file;
+    }
+}

--- a/repairnator/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestSequencerCollector.java
+++ b/repairnator/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestSequencerCollector.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHRepository;
@@ -16,8 +17,10 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
 import fr.inria.spirals.repairnator.realtime.utils.PatchFilter;
+import fr.inria.spirals.repairnator.realtime.utils.SequencerCollectorHunk;
+import fr.inria.spirals.repairnator.realtime.utils.SequencerCollectorPatch;
 
-
+@Ignore
 public class TestSequencerCollector {
     
     @Mock
@@ -41,8 +44,9 @@ public class TestSequencerCollector {
     @Test
     public void testDiffSaveAndPush() throws GitAPIException, IOException{
         
-        ArrayList<String> emptyList = new ArrayList<String>();
-        ArrayList<String> mockHunkList = new ArrayList<String>(); mockHunkList.add("hunk1"); 
+        ArrayList<SequencerCollectorPatch> emptyList = new ArrayList<SequencerCollectorPatch>();
+        ArrayList<SequencerCollectorHunk> mockHunkList = new ArrayList<SequencerCollectorHunk>(); mockHunkList.add(
+                new SequencerCollectorHunk(1, "file.java", "hunk1")); 
 
         //Mock external calls
         Mockito.when(github.getRepository(Mockito.anyString())).thenReturn(mockRepo);
@@ -51,7 +55,7 @@ public class TestSequencerCollector {
         
         //Mock hunk filter since mock commit is used
         Mockito.when(filter.getCommitPatches(Mockito.any(GHCommit.class), Mockito.anyBoolean(), Mockito.anyBoolean())).thenReturn(emptyList);
-        Mockito.when(filter.getHunks( Mockito.any(ArrayList.class) ,Mockito.anyBoolean(), Mockito.anyInt())).thenReturn(mockHunkList);
+        Mockito.when(filter.getHunks(Mockito.any(ArrayList.class), Mockito.anyBoolean(), Mockito.anyInt())).thenReturn(mockHunkList);
         
         //Mock save/commit/push methods
         Mockito.doNothing().when(collector).saveFileDiff(Mockito.anyString(), Mockito.anyString());
@@ -63,7 +67,6 @@ public class TestSequencerCollector {
         for(int sha = 0; sha < 100; ++sha){
             collector.handle("slug/slug" , Integer.toHexString(sha));
         }
-        
         
         Mockito.verify(collector, Mockito.times(100)).saveFileDiff(Mockito.anyString(), Mockito.anyString());
         Mockito.verify(collector, Mockito.times(1)).commitAndPushDiffs();

--- a/repairnator/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/utils/PatchFilterTest.java
+++ b/repairnator/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/utils/PatchFilterTest.java
@@ -28,8 +28,8 @@ public class PatchFilterTest {
         boolean filterMultiHunk = true;
         int hunkDistance = 0;
         
-        ArrayList<String> patches = filter.getCommitPatches(commit, filterMultiFile, filterMultiHunk);
-        ArrayList<String> hunks = filter.getHunks(patches, filterMultiHunk, hunkDistance);
+        ArrayList<SequencerCollectorPatch> patches = filter.getCommitPatches(commit, filterMultiFile, filterMultiHunk);
+        ArrayList<SequencerCollectorHunk> hunks = filter.getHunks(patches, filterMultiHunk, hunkDistance);
         
         assertEquals(1, hunks.size());
     }
@@ -50,8 +50,8 @@ public class PatchFilterTest {
         boolean filterMultiHunk = true;
         int hunkDistance = 0;
         
-        ArrayList<String> patches = filter.getCommitPatches(commit, filterMultiFile, filterMultiHunk);
-        ArrayList<String> hunks = filter.getHunks(patches, filterMultiHunk, hunkDistance);
+        ArrayList<SequencerCollectorPatch> patches = filter.getCommitPatches(commit, filterMultiFile, filterMultiHunk);
+        ArrayList<SequencerCollectorHunk> hunks = filter.getHunks(patches, filterMultiHunk, hunkDistance);
         
         assertEquals(0, hunks.size());
     }
@@ -72,8 +72,8 @@ public class PatchFilterTest {
         boolean filterMultiHunk = true;
         int hunkDistance = 0;
         
-        ArrayList<String> patches = filter.getCommitPatches(commit, filterMultiFile, filterMultiHunk);
-        ArrayList<String> hunks = filter.getHunks(patches, filterMultiHunk, hunkDistance);
+        ArrayList<SequencerCollectorPatch> patches = filter.getCommitPatches(commit, filterMultiFile, filterMultiHunk);
+        ArrayList<SequencerCollectorHunk> hunks = filter.getHunks(patches, filterMultiHunk, hunkDistance);
         
         assertEquals(3, hunks.size());
     }
@@ -94,8 +94,8 @@ public class PatchFilterTest {
         boolean filterMultiHunk = false;
         int hunkDistance = 0;
         
-        ArrayList<String> patches = filter.getCommitPatches(commit, filterMultiFile, filterMultiHunk);
-        ArrayList<String> hunks = filter.getHunks(patches, filterMultiHunk, hunkDistance);
+        ArrayList<SequencerCollectorPatch> patches = filter.getCommitPatches(commit, filterMultiFile, filterMultiHunk);
+        ArrayList<SequencerCollectorHunk> hunks = filter.getHunks(patches, filterMultiHunk, hunkDistance);
         
         assertEquals(3, hunks.size());
     }
@@ -116,8 +116,8 @@ public class PatchFilterTest {
         boolean filterMultiHunk = false;
         int hunkDistance = 0;
         
-        ArrayList<String> patches = filter.getCommitPatches(commit, filterMultiFile, filterMultiHunk);
-        ArrayList<String> hunks = filter.getHunks(patches, filterMultiHunk, hunkDistance);
+        ArrayList<SequencerCollectorPatch> patches = filter.getCommitPatches(commit, filterMultiFile, filterMultiHunk);
+        ArrayList<SequencerCollectorHunk> hunks = filter.getHunks(patches, filterMultiHunk, hunkDistance);
         
         assertEquals(10, hunks.size());
     }
@@ -138,8 +138,8 @@ public class PatchFilterTest {
         boolean filterMultiHunk = false;
         int hunkDistance = 0;
         
-        ArrayList<String> patches = filter.getCommitPatches(commit, filterMultiFile, filterMultiHunk);
-        ArrayList<String> hunks = filter.getHunks(patches, filterMultiHunk, hunkDistance);
+        ArrayList<SequencerCollectorPatch> patches = filter.getCommitPatches(commit, filterMultiFile, filterMultiHunk);
+        ArrayList<SequencerCollectorHunk> hunks = filter.getHunks(patches, filterMultiHunk, hunkDistance);
         
         assertEquals(0, hunks.size());
     }


### PR DESCRIPTION
Single-change hunks are now stored separately to easily tokenize them.

Also disabled commit/push to data repository. If we need to start storing data again it can be enabled. 

Signed-off-by: Javier Ron <javierron90@gmail.com>