### PR TITLE
feat: PipelineBuildListener handles 4 different message types.

### DIFF
--- a/doc/repairnator-kubernetes.md
+++ b/doc/repairnator-kubernetes.md
@@ -59,6 +59,10 @@ Regarding the format of queue messages, repairnator pipeline supports the follow
 - a bytes message with a build id only  
 - a bytes message with a JSON string
 
+```json
+{"buildId":"648902893","CI":"travis-ci.org"}
+```
+
 Check the pipeline output by
 
 ```

--- a/doc/repairnator-kubernetes.md
+++ b/doc/repairnator-kubernetes.md
@@ -52,6 +52,13 @@ Send a build id to queue
 python /queue-for-buildids/publisher.py -d /queue/pipeline 566070885
 ```
 
+Regarding the format of queue messages, repairnator pipeline supports the following ones:
+
+- a plain text with a build id only  
+- a plain text with a JSON string  
+- a bytes message with a build id only  
+- a bytes message with a JSON string
+
 Check the pipeline output by
 
 ```

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineBuildListener.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineBuildListener.java
@@ -1,0 +1,46 @@
+package fr.inria.spirals.repairnator.pipeline;
+
+import org.apache.activemq.command.ActiveMQBytesMessage;
+import org.apache.activemq.command.ActiveMQTextMessage;
+import org.apache.activemq.util.ByteSequence;
+import org.junit.Test;
+
+import javax.jms.MessageNotWriteableException;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestPipelineBuildListener {
+    @Test
+    public void testMessageExtractor() {
+        PipelineBuildListener buildListener = new PipelineBuildListener(null);
+        ActiveMQTextMessage textMessage = new ActiveMQTextMessage();
+
+        try {
+            textMessage.setText("1");
+        } catch (MessageNotWriteableException e) {
+            e.printStackTrace();
+        }
+        // a plain-text message which only contains a build id
+        assertEquals(1, buildListener.extractBuiltId(textMessage));
+
+        try {
+            textMessage.setText("{\"buildId\":\"2\",\"CI\":\"travis-ci.org\"}");
+        } catch (MessageNotWriteableException e) {
+            e.printStackTrace();
+        }
+        // a plain-text message which is in json
+        assertEquals(2, buildListener.extractBuiltId(textMessage));
+
+        ActiveMQBytesMessage bytesMessage = new ActiveMQBytesMessage();
+        bytesMessage.setContent(new ByteSequence("3".getBytes()));
+        bytesMessage.setReadOnlyBody(true);
+        // a bytes message which only contains a build id
+        assertEquals(3, buildListener.extractBuiltId(bytesMessage));
+
+        ActiveMQBytesMessage bytesMessageInJson = new ActiveMQBytesMessage();
+        bytesMessageInJson.setContent(new ByteSequence("{\"buildId\":\"4\",\"CI\":\"travis-ci.org\"}".getBytes()));
+        bytesMessageInJson.setReadOnlyBody(true);
+        // a bytes message whose content is formatted in json
+        assertEquals(4, buildListener.extractBuiltId(bytesMessageInJson));
+    }
+}


### PR DESCRIPTION
- a plain text with a build id only
- a plain text with a JSON string
- a bytes message with a build id only
- a bytes message with a JSON string

The corresponding test case has been added to this PR. The formats have been documented in `doc/repairnator-kubernetes.md `.

Signed-off-by: Long Zhang <zhanglong3030@qq.com>