### PR TITLE
refactor: removing printUsage() when an error is found

### DIFF
--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
@@ -422,7 +422,6 @@ public class LauncherUtils {
             for (java.util.Iterator<?> errs = arguments.getErrorMessageIterator(); errs.hasNext();) {
                 System.err.println("Error: " + errs.next());
             }
-            printUsage(jsap, launcherType);
         }
 
         if (getArgHelp(arguments)) {


### PR DESCRIPTION
By removing ``printUsage()`` it becomes easier to understand if it's an actual error or a misusage. 