### PR TITLE
feat: continuous deployment on K8S from Travis

### DIFF
--- a/.travis/kubeconfig.skeleton
+++ b/.travis/kubeconfig.skeleton
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Config
+preferences: {}
+
+# Define the cluster
+clusters:
+- cluster:
+    certificate-authority-data: K8S_CERTIFICATE_AUTHORITY_DATA
+    # You'll need the API endpoint of your Cluster here:
+    server: 'https://kubeapi.kth-assert.net:6443'
+  name: repairnator-k8s
+
+# Define the user
+users:
+- name: repairnator-admin
+  user:
+    as-user-extra: {}
+    client-key-data: K8S_CLIENT_KEY_DATA
+    token: K8S_TOKEN
+
+# Define the context: linking a user to a cluster
+contexts:
+- context:
+    cluster: repairnator-k8s
+    namespace: repairnator
+    user: repairnator-admin
+  name: repairnator
+
+# Define current context
+current-context: repairnator

--- a/.travis/travis-deploy.sh
+++ b/.travis/travis-deploy.sh
@@ -4,6 +4,11 @@ set -e
 sudo apt-get update
 sudo apt-get install -y xmlstarlet
 
+# install the latest kubectl
+sudo curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \
+  && sudo chmod +x ./kubectl \
+  && sudo mv ./kubectl /usr/local/bin/
+
 ### MAVEN CENTRAL
 if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
     cp .travis/travis-settings.xml $HOME/.m2/settings.xml
@@ -45,6 +50,17 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
         exit 1
     else
         echo "Docker image pushed"
+
+        ### KUBERNETES
+        echo "Restart the repairnator pipelines hosted in the k8s"
+        # build the .kube directory and setup the config
+        mkdir ${HOME}/.kube
+        cp .travis/kubeconfig.skeleton ${HOME}/.kube/config
+        sed -i 's/K8S_CERTIFICATE_AUTHORITY_DATA/'"$K8S_CERTIFICATE_AUTHORITY_DATA"'/g' ${HOME}/.kube/config
+        sed -i 's/K8S_CLIENT_KEY_DATA/'"$K8S_CLIENT_KEY_DATA"'/g' ${HOME}/.kube/config
+        sed -i 's/K8S_TOKEN/'"$K8S_TOKEN"'/g' ${HOME}/.kube/config
+        # remove the current pipeline pods, k8s will automatically recreate them using the latest image
+        kubectl delete pod $(kubectl get pods -n repairnator -l app=repairnator-pipeline -o custom-columns=NAME:.metadata.name --no-headers=true) -n repairnator
     fi
 fi
 


### PR DESCRIPTION
This PR adds the following steps in .travis/travis-deploy.sh to solve #1039 :
- install the latest `kubectl` binary
- setup the kube config, which connects to our K8s cluster
- execute `kubectl` command to delete the current pipeline pods, so that the k8s cluster could recreate new ones using the updated image

The following ENVs need to be setup via Travis configuration:
- K8S_CERTIFICATE_AUTHORITY_DATA
- K8S_CLIENT_KEY_DATA
- K8S_TOKEN

Signed-off-by: Long Zhang <zhanglong3030@qq.com>