### PR TITLE
fix: a path error when restarting pipeline pods

### DIFF
--- a/.travis/travis-deploy.sh
+++ b/.travis/travis-deploy.sh
@@ -53,6 +53,8 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
 
         ### KUBERNETES
         echo "Restart the repairnator pipelines hosted in the k8s"
+        # back to the root folder of the project
+        cd ..
         # build the .kube directory and setup the config
         mkdir ${HOME}/.kube
         cp .travis/kubeconfig.skeleton ${HOME}/.kube/config


### PR DESCRIPTION
The k8s related commands should be executed at the root folder of the project. This PR fixes the error `cp: cannot stat '.travis/kubeconfig.skeleton': No such file or directory` in travis. (e.g., https://travis-ci.org/eclipse/repairnator/jobs/658817214#L484)

Signed-off-by: Long Zhang <zhanglong3030@qq.com>