### PR TITLE
Remove "target" folder from the files to push

### DIFF
--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/files/FileHelper.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/files/FileHelper.java
@@ -188,6 +188,13 @@ public class FileHelper {
         }
     }
 
+    /**
+     * It allows to avoid that the "target" folder of the project under repair is pushed.
+     * To do this, it updates the existing .gitignore file (or it creates it from scratch
+     * if it does not exist), adding a rule to ignore the "target" folder.
+     *
+     * @param directory the root of the project under repair.
+     */
     public static void removeTargetFolderFromFilesToPush(File directory) {
     	boolean isGitignoreFilePresent = false;
     	File[] fileList = directory.listFiles();

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/files/FileHelper.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/files/FileHelper.java
@@ -1,12 +1,19 @@
 package fr.inria.spirals.repairnator.process.files;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileFilter;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -182,5 +189,41 @@ public class FileHelper {
                 }
             }
         }
+    }
+
+    public static void removeTargetFolderFromFilesToPush(File directory) {
+    	boolean isGitignoreFilePresent = false;
+    	File[] fileList = directory.listFiles();
+    	String targetFolder = "target/";
+
+    	for (int i = 0; i < fileList.length && !isGitignoreFilePresent; i++) {
+            if (fileList[i].isFile() && fileList[i].getName().equals(".gitignore")) {
+            	isGitignoreFilePresent = true;
+            	try {
+					List<String> fileContent = Files.readAllLines(Paths.get(fileList[i].getAbsolutePath()));
+
+					if (!fileContent.contains(targetFolder)) {
+						try {
+							Writer output = new BufferedWriter(new FileWriter(fileList[i].getAbsolutePath(), true));
+							output.append("\n# Added by Repairnator\n" + targetFolder);
+							output.close();
+						} catch (IOException e) {
+							e.printStackTrace();
+						}
+					}
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+            }
+        }
+    	if (!isGitignoreFilePresent) {
+    		Path path = Paths.get(directory + File.separator + ".gitignore");
+    		try {
+    			String text = "# Added by Repairnator\n" + targetFolder;
+				Files.write(path, text.getBytes());
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+    	}
     }
 }

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/files/FileHelper.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/files/FileHelper.java
@@ -1,11 +1,8 @@
 package fr.inria.spirals.repairnator.process.files;
 
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileFilter;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
@@ -208,7 +205,7 @@ public class FileHelper {
 						output.close();
 					}
 				} catch (IOException e) {
-					getLogger().warn("removeTargetFolderFromFilesToPush", e);
+					getLogger().warn("Error with removeTargetFolderFromFilesToPush method when .gitignore file exists", e);
 				}
             }
         }
@@ -218,7 +215,7 @@ public class FileHelper {
     			String text = "# Added by Repairnator\n" + targetFolder;
 				Files.write(path, text.getBytes());
 			} catch (IOException e) {
-				e.printStackTrace();
+				getLogger().warn("Error with removeTargetFolderFromFilesToPush method when .gitignore file does not exist", e);
 			}
     	}
     }

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/files/FileHelper.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/files/FileHelper.java
@@ -203,16 +203,12 @@ public class FileHelper {
 					List<String> fileContent = Files.readAllLines(Paths.get(fileList[i].getAbsolutePath()));
 
 					if (!fileContent.contains(targetFolder)) {
-						try {
-							Writer output = new BufferedWriter(new FileWriter(fileList[i].getAbsolutePath(), true));
-							output.append("\n# Added by Repairnator\n" + targetFolder);
-							output.close();
-						} catch (IOException e) {
-							e.printStackTrace();
-						}
+						Writer output = new BufferedWriter(new FileWriter(fileList[i].getAbsolutePath(), true));
+						output.append("\n# Added by Repairnator\n" + targetFolder);
+						output.close();
 					}
 				} catch (IOException e) {
-					e.printStackTrace();
+					getLogger().warn("removeTargetFolderFromFilesToPush", e);
 				}
             }
         }

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/push/CommitFiles.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/push/CommitFiles.java
@@ -48,6 +48,8 @@ public class CommitFiles extends AbstractStep {
 
             FileHelper.removeGhOauthFromCreatedFilesToPush(targetDir, this.getInspector().getJobStatus().getCreatedFilesToPush());
 
+            FileHelper.removeTargetFolderFromFilesToPush(targetDir);
+
             try {
                 Git git;
 


### PR DESCRIPTION
Repairnator now checks if the `target` folder is ignored or not by Git, and checks if the `.gitignore` file is present or not.

In the first case, if the .`gitignore` file is present, but the `target` folder is not ignored, Repairnator adds these lines to the file:

```
# Added by Repairnator
target/
```

In the second case, if the `.gitignore` file is not present, Repairnator creates the file and writes the same content of the first case.

In this way, Repairnator doesn't push the `target` folder to GitHub, avoiding the publication of the GitHub token contained in some files of the folder `target/surefire-reports`.

Signed-off-by: ginellidavide@gmail.com <ginellidavide@gmail.com>