### PR TITLE
Fix: should not be null in outputdir name 

### DIFF
--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/GitRepositoryLauncherUtils.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/GitRepositoryLauncherUtils.java
@@ -86,7 +86,9 @@ public class GitRepositoryLauncherUtils {
 
             String path = config.getOutputPath();
 
-            path += File.separator + config.getGitRepositoryId();
+            if (config.getGitRepositoryId() != null) {
+                path += File.separator + config.getGitRepositoryId();
+            }
             
             fileSerializerEngines.add(new CSVSerializerEngine(path));
             fileSerializerEngines.add(new JSONFileSerializerEngine(path));


### PR DESCRIPTION
 should not be null in outputdir name if no commit hash provided.
Sneaky bug can cause fail in contexts such as in Jenkins.  :)

