### PR TITLE
fix: updated repairnator-pipeline-test dependency workaround

### DIFF
--- a/.travis/travis-run-pipeline.sh
+++ b/.travis/travis-run-pipeline.sh
@@ -4,4 +4,11 @@
 set -e
 export M2_HOME=/usr/local/maven
 
+sudo apt-get update
+sudo apt-get install -y xmlstarlet
+
+
+VERSION=`xmlstarlet sel -t -v '//_:project/_:properties/_:revision' src/pom.xml`
+sed -i -e 's/\${revision}/'$VERSION'/' src/repairnator-core/pom.xml
+
 mvn clean install -B -f src/repairnator-core/ && mvn -Dtest=$TEST_LIST clean test -B -f $TEST_PATH

--- a/src/repairnator-core/pom.xml
+++ b/src/repairnator-core/pom.xml
@@ -31,38 +31,4 @@
             <version>8.11.1</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>copy-resources</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <resources>
-                                <resource>
-                                    <directory>./</directory>
-                                    <filtering>true</filtering>
-                                </resource>
-                            </resources>
-                            <outputDirectory>target</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <configuration>
-                    <pomFile>target/pom.xml</pomFile>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
- Previous workaround caused repairnator-core pom files to conflict and fail CD
- It's now consistent with same type of workaround implemented in the [deploy script](https://github.com/eclipse/repairnator/blob/13da69a8d64d05d070bb5a63095f503038ac6181/.travis/travis-deploy.sh#L18)

Signed-off-by: Javier Ron <javierron90@gmail.com>