### PR TITLE
Fix Sequencer integration

### DIFF
--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/SequencerConfig.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/SequencerConfig.java
@@ -1,0 +1,42 @@
+package fr.inria.spirals.repairnator.config;
+
+/**
+ * Configuration manager for Sequencer repair step:
+ * Config values are read directly as environment variables,
+ * so that we avoid adding more options through the launcher's
+ * command line args.
+ */
+public final class SequencerConfig {
+
+    public final String dockerTag;
+    public final int threads;
+    public final int beam_size;
+    public final int timeout;
+
+    private static SequencerConfig instance;
+
+    private SequencerConfig(){
+        this.dockerTag = getEnvOrDefault("SEQUENCER_DOCKER_TAG", "repairnator/sequencer:2.0");
+        this.threads = Integer.parseInt(getEnvOrDefault("SEQUENCER_THREADS", "4"));
+        this.beam_size = Integer.parseInt(getEnvOrDefault("SEQUENCER_BEAM_SIZE", "50"));
+        this.timeout = Integer.parseInt(getEnvOrDefault("SEQUENCER_TIMEOUT", "120"));
+    }
+
+    private String getEnvOrDefault(String name, String dfault){
+
+        String env = System.getenv(name);
+        if(env == null || env.equals(""))
+            return dfault;
+
+        return env;
+    }
+
+    public static SequencerConfig getInstance(){
+        if (instance == null)
+            instance = new SequencerConfig();
+
+        return instance;
+    }
+
+
+}

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/dockerpool/RunnablePipelineContainer.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/dockerpool/RunnablePipelineContainer.java
@@ -7,6 +7,7 @@ import com.spotify.docker.client.messages.ContainerCreation;
 import com.spotify.docker.client.messages.ContainerExit;
 import com.spotify.docker.client.messages.HostConfig;
 import fr.inria.spirals.repairnator.InputBuildId;
+import fr.inria.spirals.repairnator.config.SequencerConfig;
 import fr.inria.spirals.repairnator.utils.DateUtils;
 import fr.inria.spirals.repairnator.utils.Utils;
 import fr.inria.spirals.repairnator.config.RepairnatorConfig;
@@ -105,6 +106,14 @@ public class RunnablePipelineContainer implements Runnable {
 
         if (this.repairnatorConfig.getLauncherMode() == LauncherMode.REPAIR || this.repairnatorConfig.getLauncherMode() == LauncherMode.CHECKSTYLE) {
             this.envValues.add("REPAIR_TOOLS=" + StringUtils.join(this.repairnatorConfig.getRepairTools(), ","));
+        }
+
+        if (this.repairnatorConfig.getRepairTools().contains("SequencerRepair")) {
+            SequencerConfig sequencerConfig = SequencerConfig.getInstance();
+            this.envValues.add("SEQUENCER_DOCKER_TAG=" + sequencerConfig.dockerTag);
+            this.envValues.add("SEQUENCER_THREADS=" + sequencerConfig.threads);
+            this.envValues.add("SEQUENCER_BEAM_SIZE=" + sequencerConfig.beam_size);
+            this.envValues.add("SEQUENCER_TIMEOUT=" + sequencerConfig.timeout);
         }
     }
 

--- a/src/repairnator-pipeline/pom.xml
+++ b/src/repairnator-pipeline/pom.xml
@@ -28,9 +28,19 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.12</version>
+        </dependency>
+        <dependency>
             <groupId>se.kth.castor</groupId>
             <artifactId>sonarqube-repair</artifactId>
             <version>1.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>fr.inria.repairnator</groupId>
+            <artifactId>repairnator-core</artifactId>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.github.spoonlabs</groupId>
@@ -54,11 +64,6 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>fr.inria.repairnator</groupId>
-            <artifactId>repairnator-core</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/SequencerResult.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/SequencerResult.java
@@ -38,10 +38,11 @@ public class SequencerResult {
             diffs = new ArrayList<>();
             if (success) {
                 for (File patchDir : patchDirs) {
-                    for (File patchFile : patchDir.listFiles()) {
+                    File[] patchFiles = patchDir.listFiles(file -> file.getName().equals("diff"));
+                    for (File patchFile : patchFiles) {
                         try {
                             List<String> diffList = Files.readLines(patchFile, Charsets.UTF_8);
-                            String diff = diffList.stream().collect(Collectors.joining());
+                            String diff = String.join("\n", diffList);
                             diffs.add(diff);
                         } catch (IOException e) {
                             e.printStackTrace();

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/SequencerResult.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/SequencerResult.java
@@ -1,12 +1,10 @@
 package fr.inria.spirals.repairnator.process.step.repair.sequencer;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
-
-import java.io.File;
-import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,33 +21,30 @@ public class SequencerResult {
     private String outputDirPath;
     private String message;
     private String warning;
-    private boolean success;
     private List<String> diffs;
 
-    public SequencerResult(String buggyFilePath, String outputDirPath, String message, String warning) {
+    public SequencerResult(String buggyFilePath, String outputDirPath, String message, String warning)
+            throws Exception {
+
         this.buggyFilePath = buggyFilePath;
         this.outputDirPath = outputDirPath;
         this.message = message;
         this.warning = warning;
-        File outputDir = new File(outputDirPath);
-        if (outputDir.exists() && outputDir.isDirectory()) {
-            List<File> patchDirs = Arrays.asList(outputDir.listFiles());
-            success = patchDirs.size() > 0;
-            diffs = new ArrayList<>();
-            if (success) {
-                for (File patchDir : patchDirs) {
-                    File[] patchFiles = patchDir.listFiles(file -> file.getName().equals("diff"));
-                    for (File patchFile : patchFiles) {
-                        try {
-                            List<String> diffList = Files.readLines(patchFile, Charsets.UTF_8);
-                            String diff = String.join("\n", diffList);
-                            diffs.add(diff);
-                        } catch (IOException e) {
-                            e.printStackTrace();
-                        }
-                    }
-                }
-            }
+        Path outputDir = Paths.get(outputDirPath);
+
+        if (!Files.exists(outputDir) || !Files.isDirectory(outputDir))
+            throw new Exception("Error while reading sequencer result files: " +
+                    "Output path does not exist or is not a directory");
+
+        List<Path> patchDirs = Files.walk(outputDir)
+                .filter(file -> Files.isRegularFile(file) && file.getFileName().toString().equals("diff"))
+                .collect(Collectors.toList());
+
+        this.diffs = new ArrayList<>();
+        for (Path file : patchDirs){
+            List<String> diffLines = Files.readAllLines(file, Charset.forName("UTF-8"));
+            String diff = String.join("\n", diffLines);
+            diffs.add(diff);
         }
     }
 
@@ -70,7 +65,7 @@ public class SequencerResult {
     }
 
     public boolean isSuccess() {
-        return this.success;
+        return diffs.size() > 0;
     }
 
     public List<String> getDiffs() {

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/detection/AstorDetectionStrategy.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/detection/AstorDetectionStrategy.java
@@ -1,0 +1,65 @@
+package fr.inria.spirals.repairnator.process.step.repair.sequencer.detection;
+
+import fr.inria.astor.approaches._3sfix.ZmEngine;
+import fr.inria.astor.core.entities.SuspiciousModificationPoint;
+import fr.inria.main.CommandSummary;
+import fr.inria.main.evolution.AstorMain;
+import fr.inria.spirals.repairnator.process.inspectors.JobStatus;
+import fr.inria.spirals.repairnator.process.inspectors.ProjectInspector;
+import fr.inria.spirals.repairnator.process.step.repair.sequencer.SequencerRepair;
+import org.apache.commons.lang.StringUtils;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AstorDetectionStrategy implements DetectionStrategy {
+
+    @Override
+    public List<ModificationPoint> detect(SequencerRepair repairStep) {
+
+        ProjectInspector inspector = repairStep.getInspector();
+        JobStatus jobStatus = inspector.getJobStatus();
+        List<URL> repairClasspath = jobStatus.getRepairClassPath();
+
+        // prepare CommandSummary
+        CommandSummary cs = new CommandSummary();
+        List<String> dependencies = new ArrayList<>();
+
+        for (URL url : repairClasspath) {
+            if (url.getFile().endsWith(".jar")) {
+                dependencies.add(url.getPath());
+            }
+        }
+//        cs.command.put("-loglevel", "DEBUG");
+        cs.command.put("-mode", "custom");
+        cs.command.put("-dependencies", StringUtils.join(dependencies,":"));
+        cs.command.put("-location", jobStatus.getFailingModulePath());
+//        cs.command.put("-ingredientstrategy", "fr.inria.astor.test.repair.evaluation.extensionpoints.ingredients.MaxLcsSimSearchStrategy");
+        cs.command.put("-flthreshold", "0.5");
+        cs.command.put("-maxgen", "0");
+//        cs.command.put("-population", "1");
+//        cs.command.put("-seed", "1");
+        cs.command.put("-javacompliancelevel", "8");
+        cs.command.put("-customengine", ZmEngine.class.getCanonicalName());
+        cs.command.put("-parameters", "disablelog:false:logtestexecution:true:logfilepath:"
+                + inspector.getRepoLocalPath()
+                + "/repairnator." + "sequencerRepair" + ".log");
+
+        AstorMain astorMain = new AstorMain();
+        try {
+            astorMain.execute(cs.flat());
+        } catch (Exception e) {
+            repairStep.addStepError("Got exception when running SequencerRepair: ", e);
+        }
+        // construct ZmEngine
+        ZmEngine zmengine = (ZmEngine) astorMain.getEngine();
+        List<SuspiciousModificationPoint> suspicious = zmengine.getSuspicious();
+
+        return suspicious.stream()
+                .map(ModificationPoint::CreateFrom)
+                .collect(Collectors.toList()
+        );
+    }
+}

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/detection/DetectionStrategy.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/detection/DetectionStrategy.java
@@ -1,0 +1,8 @@
+package fr.inria.spirals.repairnator.process.step.repair.sequencer.detection;
+
+import fr.inria.spirals.repairnator.process.step.repair.sequencer.SequencerRepair;
+import java.util.List;
+
+public interface DetectionStrategy {
+    List<ModificationPoint> detect(SequencerRepair repairStep);
+}

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/detection/ModificationPoint.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/detection/ModificationPoint.java
@@ -3,7 +3,6 @@ package fr.inria.spirals.repairnator.process.step.repair.sequencer.detection;
 import fr.inria.astor.core.entities.SuspiciousModificationPoint;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class ModificationPoint {
     private Path filePath;

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/detection/ModificationPoint.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/detection/ModificationPoint.java
@@ -1,0 +1,36 @@
+package fr.inria.spirals.repairnator.process.step.repair.sequencer.detection;
+
+import fr.inria.astor.core.entities.SuspiciousModificationPoint;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class ModificationPoint {
+    private Path filePath;
+    private int suspiciousLine;
+
+    public static ModificationPoint CreateFrom(SuspiciousModificationPoint p) {
+        return new ModificationPoint(
+                p.getCodeElement().getPosition().getFile().toPath(),
+                p.getSuspicious().getLineNumber()
+        );
+    }
+
+//    log based detection placeholder
+//    public static ModificationPoint CreateFrom(LogBasedModificationPoint p) {
+//        return new ModificationPoint(p);
+//    }
+
+    public ModificationPoint(Path filepath, int suspiciousLine){
+        this.filePath = filepath;
+        this.suspiciousLine = suspiciousLine;
+    }
+
+    public int getSuspiciousLine() {
+        return suspiciousLine;
+    }
+
+    public Path getFilePath() {
+        return filePath;
+    }
+}

--- a/src/scripts/config/sequencer.cfg
+++ b/src/scripts/config/sequencer.cfg
@@ -1,0 +1,9 @@
+set -a
+
+#### SequencerRepair Configuration
+SEQUENCER_DOCKER_TAG=repairnator/sequencer:2.0 # Sequencer Docker image.
+SEQUENCER_THREADS=4 # Max allowed parallel Sequencer prediction jobs.
+SEQUENCER_BEAM_SIZE=50 # Max number of predictions created by each Sequencer prediction job.
+SEQUENCER_TIMEOUT=120 # Timeout for each prediction job, in minutes.
+
+set +a

--- a/src/scripts/utils/init_script.sh
+++ b/src/scripts/utils/init_script.sh
@@ -14,6 +14,9 @@ command -v uuidgen >/dev/null 2>&1 || { echo >&2 "Repairnator requires uuidgen t
 echo "Read global configuration"
 . $INIT_SCRIPT_DIR/../config/repairnator.cfg
 
+echo "Read sequencer configuration"
+. $INIT_SCRIPT_DIR/../config/sequencer.cfg
+
 echo "Read user configuration"
 if [ -r ~/repairnator.cfg ]; then
     . ~/repairnator.cfg


### PR DESCRIPTION
Fixes: 
  - SequencerRepair
    - [x] Now works when used in the testPipeline test case
    - [x] No longer adds patched file to diff list
    - [x] No longer mounts the whole /tmp directory into the docker image
    - [x] Patches correctly sent to recordPatches function
    - [x] Refactor modification point search into strategy-pattern class
    - [x] Allow parallel prediction jobs
    - [x] Add `beam_size`, `image_tag`, `repairnator_threads` and `timeout` to sequencers' own config file
    - [x] Updated implementation to not start docker processes directly but instead use the DockerClient library

Signed-off-by: Javier Ron <javierron90@gmail.com>