### PR TITLE
refactor: containerized pipeline update

### DIFF
--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/SequencerRepair.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/SequencerRepair.java
@@ -85,7 +85,7 @@ public class SequencerRepair extends AbstractRepairStep {
             List<Image> images = docker.listImages(DockerClient.ListImagesParam.byName(config.dockerTag));
             if(images.size() <= 0) docker.pull(config.dockerTag);
         } catch (Exception e) {
-            return StepStatus.buildSkipped(this,"Error while retrieving sequencer docker image");
+            return StepStatus.buildSkipped(this,"Error while retrieving sequencer docker image: " + e);
         }
 
         final ExecutorService executor = Executors.newFixedThreadPool(config.threads);

--- a/src/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/DockerPipelineRunner.java
+++ b/src/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/DockerPipelineRunner.java
@@ -25,14 +25,13 @@ import java.util.concurrent.LinkedBlockingDeque;
 public class DockerPipelineRunner extends DockerPoolManager implements PipelineRunner {
     private static final Logger LOGGER = LoggerFactory.getLogger(DockerPipelineRunner.class);
     private static final int DELAY_BETWEEN_DOCKER_IMAGE_REFRESH = 60; // in minutes
-    public static final String REPAIRNATOR_PIPELINE_DOCKER_IMAGE_NAME = "repairnator/pipeline";
 
     public ExecutorService getExecutorService() {
         return executorService;
     }
 
     private ExecutorService executorService;
-    private String dockerImageId= REPAIRNATOR_PIPELINE_DOCKER_IMAGE_NAME;
+    private String dockerImageId;
     private String dockerImageName;
     private Date limitDateNextRetrieveDockerImage;
 
@@ -41,6 +40,7 @@ public class DockerPipelineRunner extends DockerPoolManager implements PipelineR
         super.setDockerOutputDir(RepairnatorConfig.getInstance().getLogDirectory());
         super.setRunId(RepairnatorConfig.getInstance().getRunId());
         super.setEngines(rtScanner.getEngines());
+        dockerImageId = RepairnatorConfig.getInstance().getDockerImageName();
     }
 
     public DockerPipelineRunner() {
@@ -50,6 +50,7 @@ public class DockerPipelineRunner extends DockerPoolManager implements PipelineR
         ArrayList<SerializerEngine> engines = new ArrayList<>();
         engines.add(new JSONFileSerializerEngine("."));
         super.setEngines(engines);
+        dockerImageId = RepairnatorConfig.getInstance().getDockerImageName();
     }
 
     public void initRunner() {


### PR DESCRIPTION
- Log containerized pipeline stdout/stderr
- Use named volumes to store containerized pipeline logs and patches
- `DockerPipelineRuner.java` now pulls the docker image name from the config file

Signed-off-by: Javier Ron <javierron90@gmail.com>