### PR TITLE
chore: revert groupId change for Maven plugin

### DIFF
--- a/src/maven-repair/pom.xml
+++ b/src/maven-repair/pom.xml
@@ -7,7 +7,7 @@
         <version>7</version>
     </parent>
 
-    <groupId>fr.inria.repairnator</groupId>
+    <groupId>fr.inria.gforge.spirals</groupId>
     <artifactId>repair-maven-plugin</artifactId>
     <version>1.6-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>


### PR DESCRIPTION
in order to avoid confusion on Maven central: https://search.maven.org/search?q=repair-maven-plugin