### PR TITLE
refactor: Add differentiated validation functions to SequencerRepair fault detection strategies

### DIFF
--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/detection/DetectionStrategy.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/detection/DetectionStrategy.java
@@ -1,8 +1,14 @@
 package fr.inria.spirals.repairnator.process.step.repair.sequencer.detection;
 
+import fr.inria.spirals.repairnator.process.inspectors.ProjectInspector;
+import fr.inria.spirals.repairnator.process.inspectors.RepairPatch;
 import fr.inria.spirals.repairnator.process.step.repair.sequencer.SequencerRepair;
+import org.slf4j.Logger;
+
 import java.util.List;
 
 public interface DetectionStrategy {
     List<ModificationPoint> detect(SequencerRepair repairStep);
+    boolean validate(RepairPatch patch);
+    void setup(ProjectInspector inspector, String pom, Logger logger);
 }

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/detection/LogParserDetectionStrategy.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/detection/LogParserDetectionStrategy.java
@@ -1,16 +1,27 @@
 package fr.inria.spirals.repairnator.process.step.repair.sequencer.detection;
 
+import fr.inria.spirals.repairnator.process.inspectors.ProjectInspector;
+import fr.inria.spirals.repairnator.process.inspectors.RepairPatch;
+import fr.inria.spirals.repairnator.process.maven.MavenHelper;
 import fr.inria.spirals.repairnator.process.step.logParser.Element;
 import fr.inria.spirals.repairnator.process.step.logParser.LogParser;
 import fr.inria.spirals.repairnator.process.step.repair.sequencer.SequencerRepair;
+import org.slf4j.Logger;
 
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
 public class LogParserDetectionStrategy implements DetectionStrategy {
 
     LogParser parser;
+    MavenPatchTester mavenTester;
+
+    void setMavenTester(MavenPatchTester tester){
+        this.mavenTester = tester;
+    }
+
 
     public LogParserDetectionStrategy(){
         parser = new LogParser();
@@ -31,5 +42,17 @@ public class LogParserDetectionStrategy implements DetectionStrategy {
                 .collect(Collectors.toList());
 
         return points;
+    }
+
+    @Override
+    public boolean validate(RepairPatch patch) {
+        Properties properties = new Properties();
+        properties.setProperty(MavenHelper.SKIP_TEST_PROPERTY, "true");
+        return mavenTester.apply(patch, "package", properties);
+    }
+
+    @Override
+    public void setup(ProjectInspector inspector, String pom, Logger logger) {
+        setMavenTester(new MavenPatchTester(inspector, pom, logger));
     }
 }

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/detection/MavenPatchTester.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/detection/MavenPatchTester.java
@@ -1,0 +1,62 @@
+package fr.inria.spirals.repairnator.process.step.repair.sequencer.detection;
+
+import fr.inria.spirals.repairnator.process.inspectors.ProjectInspector;
+import fr.inria.spirals.repairnator.process.inspectors.RepairPatch;
+import fr.inria.spirals.repairnator.process.maven.MavenHelper;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.ResetCommand;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Paths;
+import java.util.Properties;
+import java.util.UUID;
+import org.slf4j.Logger;
+
+public class MavenPatchTester {
+
+    ProjectInspector inspector;
+    String pom;
+    Logger logger;
+
+    MavenPatchTester(ProjectInspector inspector, String pom, Logger logger){
+        this.inspector = inspector;
+        this.pom = pom;
+        this.logger = logger;
+    }
+
+    public boolean apply(RepairPatch patch, String goal, Properties properties){
+
+        //Create replica as git branch and apply patch
+        logger.info("testing patch: " + patch.getFilePath());
+        String patchName = Paths.get(patch.getFilePath()).getFileName().toString() + "-" + UUID.randomUUID();
+        boolean success = false;
+        try {
+            Git git = Git.open(new File(inspector.getRepoLocalPath()));
+            String defaultBranch = git.getRepository().getBranch();
+
+            git.branchCreate().setStartPoint(defaultBranch).setName(patchName).call();
+            git.checkout().setName(patchName).call();
+
+            InputStream is = new ByteArrayInputStream(patch.getDiff().getBytes());
+            git.apply().setPatch(is).call();
+
+            //Build and test with applied patch
+            MavenHelper maven = new MavenHelper(pom, goal, properties, "sequencer-builder", inspector, true);
+
+            int result  = maven.run();
+
+            git.reset().setMode(ResetCommand.ResetType.HARD).call();
+
+            git.checkout().setName(defaultBranch).call();
+            git.branchDelete().setBranchNames(patchName).call();
+
+            return result == MavenHelper.MAVEN_SUCCESS;
+
+        } catch (Exception e) {
+            logger.error("error while testing if patch is buildable");
+            return false;
+        }
+    }
+}

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineSequencerRepair.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineSequencerRepair.java
@@ -1,6 +1,5 @@
 package fr.inria.spirals.repairnator.pipeline;
 
-import com.martiansoftware.jsap.FlaggedOption;
 import fr.inria.spirals.repairnator.process.step.AbstractStep;
 import org.junit.Test;
 
@@ -24,7 +23,7 @@ public class TestPipelineSequencerRepair {
 
     @Test
     public void TestPipelineBuildFailBranch() throws Exception{
-        // 703887431 -> javierron/faining project -> syntax error
+        // 713361530 -> javierron/faining project -> syntax error
         Launcher launcher = new Launcher(new String[]{"--build", "713361530", "--sequencerRepair" });
         // config is forced to use SequencerRepair as the only repair tool.
         assertEquals(1, launcher.getConfig().getRepairTools().size());


### PR DESCRIPTION
- Add differentiated validation functions to SequencerRepair fault detection strategies
- Handle Astor/GZoltar crash, stop pipeline and exit cleanly

Signed-off-by: Javier Ron <javierron90@gmail.com>