### PR TITLE
dox: fix link in main-classes.md

### DIFF
--- a/doc/main-classes.md
+++ b/doc/main-classes.md
@@ -10,7 +10,7 @@ The following command line tools must be installed on your machine:
   - Oracle Java: some dependencies need tools.jar in the classpath;
   - cloc: we compute some metrics with cloc;
   - git: to apply some git commands;
-  - z3: a constraint solver (the executables are available in [pipeline test resources](/repairnator/repairnator-pipeline/src/test/resources/z3)).
+  - z3: a constraint solver (the executables are available in [pipeline test resources](/src/repairnator-pipeline/src/test/resources/z3)).
 
 ```
 $ git clone https://github.com/eclipse/repairnator/


### PR DESCRIPTION
Update link after folder rename done in commit https://github.com/eclipse/repairnator/commit/c34c1497fce6fc913694fd3c486ff9ab6a0d63c1