### PR TITLE
Create new R-Hero PR message

### DIFF
--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AbstractRepairStep.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AbstractRepairStep.java
@@ -11,6 +11,7 @@ import fr.inria.spirals.repairnator.process.step.AbstractStep;
 import fr.inria.spirals.repairnator.process.step.StepStatus;
 import fr.inria.spirals.repairnator.utils.DateUtils;
 import fr.inria.spirals.repairnator.utils.Utils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.RemoteAddCommand;
@@ -24,7 +25,9 @@ import org.kohsuke.github.GitHub;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Date;
@@ -35,9 +38,7 @@ import java.util.Map;
 public abstract class AbstractRepairStep extends AbstractStep {
 
     public static final String DEFAULT_DIR_PATCHES = "repairnator-patches";
-    public static final String DEFAULT_TEXT_PR = "This patch fixes failing Travis build %(travisURL) \n\n" +
-                                        "It uses the program repair tools %(tools) \n\n" +
-                                        "If you don't want to receive those PRs in the future, [open an issue on Repairnator](https://github.com/eclipse/repairnator/issues/new?title=[BLACKLIST]%(slug))" ;
+    public static final InputStream DEFAULT_TEXT_FILE = AbstractRepairStep.class.getClassLoader().getResourceAsStream("R-Hero-PR-text.MD");
 
     public static final String GITHUB_TEXT_PR = "This patch uses the program repair tools %(tools) \n\n";
 
@@ -214,7 +215,7 @@ public abstract class AbstractRepairStep extends AbstractStep {
 
         if (prText == null) {
             StrSubstitutor sub = new StrSubstitutor(values, "%(", ")");
-            this.prText = sub.replace(DEFAULT_TEXT_PR);
+            this.prText = sub.replace(IOUtils.toString(DEFAULT_TEXT_FILE, StandardCharsets.UTF_8));
         }
 
         GHPullRequest pullRequest = originalRepository.createPullRequest(prTitle, head, base, this.prText);

--- a/src/repairnator-pipeline/src/main/resources/R-Hero-PR-text.MD
+++ b/src/repairnator-pipeline/src/main/resources/R-Hero-PR-text.MD
@@ -1,0 +1,19 @@
+## An automatic patch has been found by R-Hero! :rocket:
+
+R-Hero has found a patch for [this](%(travisURL)) failing travis-ci build
+
+----------------
+
+R-Hero is an Automatic Program Repair bot, and your feedback is very important to improve its patch generation skills. 
+If you would like to contribute, please use the links below:
+
+Do you think this patch is correct? [ [Yes](/path/to/correct) / [No](/path/to/incorrect) ]
+
+Do you think this patch is helpful? [ [Yes](/path/to/helpful) / [No](/path/to/unhelpful) ]
+
+
+-----------------------------------------------------------------------------
+
+If you would like to provide more detailed feedback:heart: to the R-Hero team, please [tell us your thoughts in an issue](https://github.com/eclipse/repairnator/issues/new?title=[FEEDBACK]%(slug)) on Repairnator
+
+If you don't want to receive more of these PRs in the future:broken_heart:, [let us know in an issue](https://github.com/eclipse/repairnator/issues/new?title=[BLACKLIST]%(slug)) on Repairnator

--- a/src/repairnator-pipeline/src/main/resources/R-Hero-PR-text.MD
+++ b/src/repairnator-pipeline/src/main/resources/R-Hero-PR-text.MD
@@ -1,16 +1,14 @@
 ### An automatic patch for you by R-Hero! :rocket:
 
-R-Hero has found a patch for [this](%(travisURL)) failing Travis CI build. [R-Hero is a bot for automatic bug fixing](https://github.com/eclipse/repairnator).
+:robot: R-Hero has found a patch for [this](%(travisURL)) failing Travis CI build. [R-Hero is a bot for automatic bug fixing](https://github.com/eclipse/repairnator), it has reproduced the bug and was able to fix it.
 
 ----------------
 
 Your feedback is very valuable to improve its patch generation skills. 
 If you would like to contribute, simply use the links below:
 
-Do you think this patch is correct? [ [Yes](/path/to/correct) / [No](/path/to/incorrect) ]
+Do you think this patch is helpful? [ [Yes :clap:](/path/to/helpful) ] / [ [Incorrect but useful :handshake:](/path/to/unhelpful) ] / [ [Useless :-1:](/path/to/incorrect) ]
 
-Do you think this patch is helpful? [ [Yes](/path/to/helpful) / [No](/path/to/unhelpful) ]
-
-If you would like to provide more detailed feedback:heart: to the R-Hero team, please [tell us your thoughts in a Github  issue](https://github.com/eclipse/repairnator/issues/new?title=[FEEDBACK]%(slug))
+If you would like to provide more detailed feedback:heart: to the R-Hero team, please [tell us your thoughts in a Github issue](https://github.com/eclipse/repairnator/issues/new?title=[FEEDBACK]%(slug))
 
 If you don't want to receive more of these PRs in the future:broken_heart:, [let us know and we'll stop sending you patches](https://github.com/eclipse/repairnator/issues/new?title=[BLACKLIST]%(slug))

--- a/src/repairnator-pipeline/src/main/resources/R-Hero-PR-text.MD
+++ b/src/repairnator-pipeline/src/main/resources/R-Hero-PR-text.MD
@@ -1,19 +1,16 @@
-## An automatic patch has been found by R-Hero! :rocket:
+### An automatic patch for you by R-Hero! :rocket:
 
-R-Hero has found a patch for [this](%(travisURL)) failing travis-ci build
+R-Hero has found a patch for [this](%(travisURL)) failing Travis CI build. [R-Hero is a bot for automatic bug fixing](https://github.com/eclipse/repairnator).
 
 ----------------
 
-R-Hero is an Automatic Program Repair bot, and your feedback is very important to improve its patch generation skills. 
-If you would like to contribute, please use the links below:
+Your feedback is very valuable to improve its patch generation skills. 
+If you would like to contribute, simply use the links below:
 
 Do you think this patch is correct? [ [Yes](/path/to/correct) / [No](/path/to/incorrect) ]
 
 Do you think this patch is helpful? [ [Yes](/path/to/helpful) / [No](/path/to/unhelpful) ]
 
+If you would like to provide more detailed feedback:heart: to the R-Hero team, please [tell us your thoughts in a Github  issue](https://github.com/eclipse/repairnator/issues/new?title=[FEEDBACK]%(slug))
 
------------------------------------------------------------------------------
-
-If you would like to provide more detailed feedback:heart: to the R-Hero team, please [tell us your thoughts in an issue](https://github.com/eclipse/repairnator/issues/new?title=[FEEDBACK]%(slug)) on Repairnator
-
-If you don't want to receive more of these PRs in the future:broken_heart:, [let us know in an issue](https://github.com/eclipse/repairnator/issues/new?title=[BLACKLIST]%(slug)) on Repairnator
+If you don't want to receive more of these PRs in the future:broken_heart:, [let us know and we'll stop sending you patches](https://github.com/eclipse/repairnator/issues/new?title=[BLACKLIST]%(slug))

--- a/src/repairnator-pipeline/src/main/resources/R-Hero-PR-text.MD
+++ b/src/repairnator-pipeline/src/main/resources/R-Hero-PR-text.MD
@@ -7,7 +7,7 @@
 Your feedback is very valuable to improve its patch generation skills. 
 If you would like to contribute, simply use the links below:
 
-Do you think this patch is helpful? [ [Yes :clap:](/path/to/helpful) ] / [ [Incorrect but useful :handshake:](/path/to/unhelpful) ] / [ [Useless :-1:](/path/to/incorrect) ]
+Do you think this patch is helpful? [ [Yes :clap:](%(helpfulURL)) ] / [ [Incorrect but useful :handshake:](%(incorrectURL)) ] / [ [Useless :-1:](%(uselessURL)) ]
 
 If you would like to provide more detailed feedback:heart: to the R-Hero team, please [tell us your thoughts in a Github issue](https://github.com/eclipse/repairnator/issues/new?title=[FEEDBACK]%(slug))
 


### PR DESCRIPTION
A PR message template for R-Hero patches.

Links still need to be added. You can see a sample [here](https://github.com/javierron/failingProject/pull/4)