### PR TITLE
fix: update R-Hero pipeline with ODS

### DIFF
--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/RepairPatch.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/RepairPatch.java
@@ -189,32 +189,29 @@ public class RepairPatch {
 
 		try {
 			// create a directory to store the patch: "patches/"+buildId+patchId
-			String buggyClassName = buggyFile.getName().split(".java")[0];
-			String rootfile = filePath.split("patch")[0] + "/patches";
-			String patchpath=rootfile+"/"+ buildId + "-" + patchId;
-			Path path = Paths
-					.get(patchpath + '/' + buggyClassName);
+			String buggyClassName = buggyFile.getName().replace(".java", "");
+			String odsFilesPath = System.getProperty("user.home") + "/ODSPatches";
+
+			String patchPath = odsFilesPath + "/" + buildId + "-" + patchId;
+			Path path = Paths.get(patchPath + '/' + buggyClassName);
 			Files.createDirectories(path);
 
 			// create buggy file and patchedFile that follows Coming structure
-			File newbuggyFile = new File(path + "/" + buildId + "-" + patchId + "_" + buggyClassName + "_s.java");
+			File newBuggyFile = new File(path + "/" + buildId + "-" + patchId + "_" + buggyClassName + "_s.java");
 			File patchedFile = new File(path + "/" + buildId + "-" + patchId + "_" + buggyClassName + "_t.java");
 
 			// copy the buggy file under the patch folder
-			Files.write(Paths.get(newbuggyFile.getPath()), buggyLines);
+			Files.write(Paths.get(newBuggyFile.getPath()), buggyLines);
 			// generate content of patchedFile by applying patches
 			List<String> patchedLines = DiffUtils.patch(buggyLines, patches);
 			Files.write(Paths.get(patchedFile.getPath()), patchedLines);
 
 			
-			 label = new RepairnatorFeatures().getLabel(new File(patchpath));
+			 label = new RepairnatorFeatures().getLabel(new File(patchPath));
 						
 
-		} catch (PatchFailedException | IOException e) {
-			throw new RuntimeException(e);
 		} catch (Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			throw new RuntimeException(e);
 		}
 
 		return label;

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AbstractRepairStep.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AbstractRepairStep.java
@@ -27,7 +27,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -168,7 +167,9 @@ public abstract class AbstractRepairStep extends AbstractStep {
         remoteAddCommand.setName("fork-patch");
         remoteAddCommand.call();
 
-        git.push().add(branchName).setRemote("fork-patch").setCredentialsProvider(new UsernamePasswordCredentialsProvider(RepairnatorConfig.getInstance().getGithubToken(), "")).call();
+        git.push().add(branchName).setRemote("fork-patch").setCredentialsProvider(
+                new UsernamePasswordCredentialsProvider(RepairnatorConfig.getInstance().getGithubToken(),"")
+        ).call();
     }
 
     protected Git createGitBranch4Push(String branchName) throws IOException{
@@ -218,7 +219,7 @@ public abstract class AbstractRepairStep extends AbstractStep {
 
         String feedbackURL =
                 FEEDBACK_URL + "/" +
-                URLEncoder.encode(this.getInspector().getRepoSlug(), StandardCharsets.UTF_8.toString()) + "/" +
+                this.getInspector().getRepoSlug() + "/" +
                 buildID;
 
         values.put("helpfulURL", feedbackURL + "/0");

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AbstractRepairStep.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AbstractRepairStep.java
@@ -45,7 +45,7 @@ public abstract class AbstractRepairStep extends AbstractStep {
 
     public static final int MAX_PATCH_PER_TOOL = 1;
 
-    public static String prTitle = "Automatic patch found by Repairnator!";
+    public static String prTitle = "Patch automatically synthesized by R-Hero! \uD83C\uDFA9";
 
     private String prText;
 

--- a/src/repairnator-pipeline/src/main/resources/R-Hero-PR-text.MD
+++ b/src/repairnator-pipeline/src/main/resources/R-Hero-PR-text.MD
@@ -1,4 +1,4 @@
-### An automatic patch for you by R-Hero! :rocket:
+### Patch automatically synthesized by R-Hero! :tophat:
 
 :robot: R-Hero has found a patch for [this](%(travisURL)) failing Travis CI build. [R-Hero is a bot for automatic bug fixing](https://github.com/eclipse/repairnator), it has reproduced the bug and was able to fix it.
 


### PR DESCRIPTION
Here is a working integration of ODS into the R-Hero pipeline.

**Other fixes**
- @SophieHYe @martinezmatias, I changed the directory where ODS saves the buggy-patched file pairs. The path used before was the one provided by the repair tool, and those paths are temporary, and get deleted after the pipeline finishes (at least on SequencerRepair). Any thoughts? Also, I think that this path should be configurable.

- Updated the feedback links on the PR text as URL encoding was not a good idea after all.

- Updated the PR text and title to be +9000 fancy. :tophat:

**Discussion**
Right now this works, but I don't like that I have called the ODS function from within the repair step. Perhaps later we can move overfitting detection to it's own pipeline step? or create a sort of switch in the AbstractRepairStep class, so that one could write in the pipeline definition for example:

```
AbstractRepairStep step = new RepairStepXYZ().SetODSLabels(true)
```

@monperrus WDYT?

Signed-off-by: Javier Ron <javierron90@gmail.com>