### PR TITLE
fix: add logging for SequencerRepair-ODS integration

### DIFF
--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/SequencerConfig.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/SequencerConfig.java
@@ -18,7 +18,8 @@ public final class SequencerConfig {
     public final int timeout;
     public final String collectorPath;
     public final int contextSize;
-    public RAW_URL_SOURCE rawURLSource;
+    public final RAW_URL_SOURCE rawURLSource;
+    public final String ODSPath;
 
     private static SequencerConfig instance;
 
@@ -30,6 +31,7 @@ public final class SequencerConfig {
         this.collectorPath = getEnvOrDefault("SEQUENCER_COLLECTOR_PATH",
                 System.getProperty("user.home") + "/continuous-learning-data");
         this.contextSize = Integer.parseInt(getEnvOrDefault("SEQUENCER_CONTEXT_SIZE", "3"));
+        this.ODSPath = (getEnvOrDefault("SEQUENCER_ODS_PATH", System.getProperty("user.home") + "/ODSPatches"));
         this.rawURLSource = parseRawURLSource();
 
     }

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/dockerpool/RunnablePipelineContainer.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/dockerpool/RunnablePipelineContainer.java
@@ -138,6 +138,7 @@ public class RunnablePipelineContainer implements Runnable {
             //to avoid creating new unnamed volumes
             Volume workspaceVolume = docker.inspectVolume("repairnator_workspace");
             Volume logsVolume = docker.inspectVolume("repairnator_logs");
+            Volume ODSVolume = docker.inspectVolume("repairnator_ods_data");
 
             HostConfig hostConfig = HostConfig.builder()
                     .appendBinds(HostConfig.Bind
@@ -154,6 +155,11 @@ public class RunnablePipelineContainer implements Runnable {
                             .builder()
                             .from(logsVolume)
                             .to("/var/log/")
+                            .build())
+                    .appendBinds(HostConfig.Bind
+                            .builder()
+                            .from(ODSVolume)
+                            .to(SequencerConfig.getInstance().ODSPath)
                             .build())
                     .build();
 

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/SequencerRepair.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/sequencer/SequencerRepair.java
@@ -257,6 +257,10 @@ public class SequencerRepair extends AbstractRepairStep {
                                                 .filter(patch -> patch.getODSLabel().equals(RepairnatorFeatures.ODSLabel.CORRECT))
                                                 .collect(Collectors.toList());
 
+        if(filteredPatches.isEmpty()){
+            return StepStatus.buildPatchNotFound(this);
+        }
+
         notify(filteredPatches);
         this.recordPatches(filteredPatches, MAX_PATCH_PER_TOOL);
         this.recordToolDiagnostic(toolDiagnostic);


### PR DESCRIPTION
- Added: write an ODS summary to a file after classification.
- Added: support to store ODS summary and files when running the pipeline in docker mode.

Signed-off-by: Javier Ron <javierron90@gmail.com>

