### PR TITLE
fix: Maven config transitions from root to child pom files

### DIFF
--- a/.ci/ci-deploy.sh
+++ b/.ci/ci-deploy.sh
@@ -6,8 +6,6 @@
 set -e
 
 sudo apt-get update
-sudo apt-get install -y xmlstarlet
-
 
 ### MAVEN CENTRAL
 if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
@@ -15,9 +13,6 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
     cd src 
     
     # pushing snapshot to https://oss.sonatype.org/content/repositories/snapshots/fr/inria/repairnator/
-    VERSION=`xmlstarlet sel -t -v '//_:project/_:properties/_:revision' pom.xml`
-    sed -i -e 's/\${revision}/'$VERSION'/' pom.xml */pom.xml
-    git diff
     mvn deploy -DskipTests -Dcheckstyle.skip
     echo Deployment to Maven Central done
 fi

--- a/.ci/ci-dockerfile
+++ b/.ci/ci-dockerfile
@@ -1,3 +1,4 @@
 FROM maven:3.6-openjdk-8
 
 RUN apt-get update
+RUN apt-get install xmlstarlet -y

--- a/.ci/ci-dockerfile
+++ b/.ci/ci-dockerfile
@@ -1,4 +1,3 @@
 FROM maven:3.6-openjdk-8
 
 RUN apt-get update
-RUN apt-get install xmlstarlet -y

--- a/.ci/ci-maven-repair.sh
+++ b/.ci/ci-maven-repair.sh
@@ -4,11 +4,6 @@
 set -e
 export M2_HOME=/usr/local/maven
 
-VERSION=`xmlstarlet sel -t -v '//_:project/_:properties/_:revision' src/pom.xml`
-sed -i -e 's/\${revision}/'$VERSION'/' src/repairnator-core/pom.xml
-sed -i -e 's/\${revision}/'$VERSION'/' src/pom.xml
-sed -i -e 's/\${revision}/'$VERSION'/' "${TEST_PATH}"/pom.xml
-
 NPEFIX_VERSION=`xmlstarlet sel -t -v '//_:dependency[_:artifactId="npefix"]/_:version' src/maven-repair/pom.xml`
 
 mvn clean install -B -f src/repairnator-core/ && mvn -Dtest=$TEST_LIST -DNPEFIX_VERSION=$NPEFIX_VERSION clean test -B -f $TEST_PATH -DskipTests

--- a/.ci/ci-run-with-core.sh
+++ b/.ci/ci-run-with-core.sh
@@ -8,9 +8,4 @@ export M2_HOME=/usr/local/maven
 # sudo apt-get update
 # sudo apt-get install -y xmlstarlet
 
-VERSION=`xmlstarlet sel -t -v '//_:project/_:properties/_:revision' src/pom.xml`
-sed -i -e 's/\${revision}/'$VERSION'/' src/repairnator-core/pom.xml
-sed -i -e 's/\${revision}/'$VERSION'/' src/pom.xml
-sed -i -e 's/\${revision}/'$VERSION'/' "${TEST_PATH}"/pom.xml
-
 mvn clean install -B -f src/repairnator-core/ && mvn -Dtest=$TEST_LIST clean test -B -f $TEST_PATH -DskipTests

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup
 pom.xml.next
+.flattened-pom.xml
 release.properties
 dependency-reduced-pom.xml
 buildNumber.properties

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -116,6 +116,31 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.1.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${maven-jacoco-plugin.version}</version>


### PR DESCRIPTION
This fixes #1155 .

See [maven docs](https://maven.apache.org/maven-ci-friendly.html#install-deploy).

Note that this should also eliminate the need for https://github.com/eclipse/repairnator/blob/6c5c1cb01ffe1e3f51d58e608827bce679588181/.travis/travis-run-with-core.sh#L11 during CI. 