### PR TITLE
chore: improve CI config

### DIFF
--- a/.ci/ci-maven-repair.sh
+++ b/.ci/ci-maven-repair.sh
@@ -7,4 +7,6 @@ export M2_HOME=/usr/share/maven
 
 NPEFIX_VERSION=`xmlstarlet sel -t -v '//_:dependency[_:artifactId="npefix"]/_:version' src/maven-repair/pom.xml`
 
-mvn clean install -B -f src/repairnator-core/ && mvn ${MAVEN_OPTS} -Dtest=$TEST_LIST -DNPEFIX_VERSION=$NPEFIX_VERSION clean test -B -f $TEST_PATH
+mvn clean install -B -f src/repairnator-core/ -DskipTests && \
+mvn clean install -B -f src/repairnator-pipeline/ -DskipTests && \
+mvn ${MAVEN_OPTS} -Dtest=$TEST_LIST -DNPEFIX_VERSION=$NPEFIX_VERSION clean test -B -f $TEST_PATH

--- a/.ci/ci-run-with-core.sh
+++ b/.ci/ci-run-with-core.sh
@@ -8,4 +8,4 @@ export M2_HOME=/usr/share/maven
 # sudo apt-get update
 # sudo apt-get install -y xmlstarlet
 
-mvn clean install -B -f src/repairnator-core/ && mvn ${MAVEN_OPTS} -Dtest=$TEST_LIST clean test -B -f $TEST_PATH
+mvn clean install -B -f src/repairnator-core/ && mvn -Dtest=$TEST_LIST clean test -B -f $TEST_PATH

--- a/.ci/ci-run-with-core.sh
+++ b/.ci/ci-run-with-core.sh
@@ -8,4 +8,4 @@ export M2_HOME=/usr/share/maven
 # sudo apt-get update
 # sudo apt-get install -y xmlstarlet
 
-mvn clean install -B -f src/repairnator-core/ && mvn -Dtest=$TEST_LIST clean test -B -f $TEST_PATH
+mvn clean install -B -f src/repairnator-core/ && mvn ${MAVEN_OPTS} -Dtest=$TEST_LIST clean test -B -f $TEST_PATH

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ spec:
         }
       }
       options {
-        timeout(time: 15, unit: "MINUTES")
+        timeout(time: 30, unit: "MINUTES")
       }
     }
     stage('repairnator-pipeline'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,7 @@ spec:
       steps {
         container('maven') {
           sh 'bash ./.ci/ci-run.sh'
+          junit testResults: 'src/repairnator-core/target/surefire-reports/*.xml'
         }
       }
       options {
@@ -63,6 +64,7 @@ spec:
       steps {
         container('maven') {
           sh 'bash ./.ci/ci-run-with-core.sh'
+          junit testResults: 'src/repairnator-realtime/target/surefire-reports/*.xml'
         }
       }
       options {
@@ -76,6 +78,7 @@ spec:
       steps {
         container('maven') {
           sh 'bash ./.ci/ci-run.sh'
+          junit testResults: 'src/repairnator-jenkins-plugin/target/surefire-reports/*.xml'
         }
       }
       options {
@@ -90,6 +93,7 @@ spec:
       steps {
         container('maven') {
           sh 'bash ./.ci/ci-maven-repair.sh'
+          junit testResults: 'src/maven-repair/target/surefire-reports/*.xml'
         }
       }
       options {
@@ -104,7 +108,7 @@ spec:
       steps {
         container('maven') {
           sh 'bash ./.ci/ci-run-with-core.sh'
-          junit testResults: 'src/repairnator-pipeline/target/surefire-reports/TEST-fr.inria.spirals.repairnator.pipeline.TestPipelinebGithubMode.xml'
+          junit testResults: 'src/repairnator-pipeline/target/surefire-reports/*.xml'
         }
       }
       options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,6 +109,7 @@ spec:
       options {
         timeout(time: 3, unit: "HOURS")
       }
+      junit skipPublishingChecks: true, 'src/repairnator-pipeline/target/surefire-reports/TEST-fr.inria.spirals.repairnator.pipeline.TestPipelinebGithubMode.xml'
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,12 +104,12 @@ spec:
       steps {
         container('maven') {
           sh 'bash ./.ci/ci-run-with-core.sh'
+          junit skipPublishingChecks: true, 'src/repairnator-pipeline/target/surefire-reports/TEST-fr.inria.spirals.repairnator.pipeline.TestPipelinebGithubMode.xml'
         }
       }
       options {
         timeout(time: 3, unit: "HOURS")
       }
-      junit skipPublishingChecks: true, 'src/repairnator-pipeline/target/surefire-reports/TEST-fr.inria.spirals.repairnator.pipeline.TestPipelinebGithubMode.xml'
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,7 +104,7 @@ spec:
       steps {
         container('maven') {
           sh 'bash ./.ci/ci-run-with-core.sh'
-          junit skipPublishingChecks: true, 'src/repairnator-pipeline/target/surefire-reports/TEST-fr.inria.spirals.repairnator.pipeline.TestPipelinebGithubMode.xml'
+          junit testResults: 'src/repairnator-pipeline/target/surefire-reports/TEST-fr.inria.spirals.repairnator.pipeline.TestPipelinebGithubMode.xml'
         }
       }
       options {


### PR DESCRIPTION
- Increase `maven-repair` timeout, as it now includes `repairnator-pipeline` as a dependency.
- Add MAVEN_OPTS do `run-with-core.sh` script.
- Activate https://github.com/jenkinsci/junit-plugin. Closes #1170