### PR TITLE
chore: repairnator-core for NPEFix unification

### DIFF
--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
@@ -705,6 +705,9 @@ public class RepairnatorConfig {
     }
 
     public String getLocalMavenRepository() {
+        if (localMavenRepository == null) {
+            setLocalMavenRepository(System.getenv("HOME") + "/.m2/repository");
+        }
         return localMavenRepository;
     }
 

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
@@ -706,7 +706,7 @@ public class RepairnatorConfig {
 
     public String getLocalMavenRepository() {
         if (localMavenRepository == null) {
-            setLocalMavenRepository(System.getenv("HOME") + "/.m2/repository");
+            setLocalMavenRepository(System.getProperty("user.home") + "/.m2/repository");
         }
         return localMavenRepository;
     }

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/utils/Pair.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/utils/Pair.java
@@ -1,0 +1,22 @@
+package fr.inria.spirals.repairnator.utils;
+
+/**
+ * Created by thomas on 10/07/17.
+ */
+public class Pair<K,V> {
+	private K key;
+	private V value;
+
+	public Pair(K key, V value) {
+		this.key = key;
+		this.value = value;
+	}
+
+	public K getKey() {
+		return key;
+	}
+
+	public V getValue() {
+		return value;
+	}
+}


### PR DESCRIPTION
- Adds default value for localMavenRepository parameter
- Move `Pair` from `maven-repair` to `repairnator-core`. Original class is still included. We need this one to avoid cyclic dependencies between modules.

We need to decide if we keep the original `Pair` class. It is not used anywhere other than NPEFix.