### PR TITLE
feat: option to fix only commits that introduce new SonarQube violations

### DIFF
--- a/doc/repair-tools.md
+++ b/doc/repair-tools.md
@@ -57,7 +57,7 @@ Additional parameters:
 * `--soraldRepairMode`: DEFAULT - the normal mode of Sorald, where the entire project is inputted. SEGMENT - the input project is sliced into smaller fixed-size segments.
 * `--soraldMaxFixesPerRule`: specify the upper bound of the number of warning fixes.
 * `--segmentSize`: the number of files per segment if Sorald runs in Segment mode.
-
+* `--soraldCommitCollectorMode`: DEFAULT - all commits are analyzed. VIOLATION_INTRODUCING - only commits that are introducing new violations of the specified types are analyzed.
 ## Sequencer
 
 [Sequencer](http://arxiv.org/pdf/1901.01808) is a repair tool based on machine learning with sequence-to-sequence. You run it as follows:

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
@@ -113,6 +113,8 @@ public class LauncherUtils {
         jsap.registerParameter(LauncherUtils.defineArgSoraldRepairMode());
         // --segmentSize
         jsap.registerParameter(LauncherUtils.defineArgSegmentSize());
+        // --soraldCommitCollectorMode
+        jsap.registerParameter(LauncherUtils.defineArgSoraldCommitCollectorMode());
         // --soraldMaxFixesPerRule
         jsap.registerParameter(LauncherUtils.defineArgSoraldMaxFixesPerRule());
 
@@ -865,6 +867,19 @@ public class LauncherUtils {
     }
 
     public static Integer getArgSegmentSize(JSAPResult arguments) {
+        return arguments.getInt("segmentSize");
+    }
+
+    public static FlaggedOption defineArgSoraldCommitCollectorMode() {
+        FlaggedOption opt = new FlaggedOption("soraldCommitCollectorMode");
+        opt.setLongFlag("soraldCommitCollectorMode");
+        opt.setStringParser(JSAP.STRING_PARSER);
+        opt.setDefault("200");
+        opt.setHelp("Segment size for the segment repair.");
+        return opt;
+    }
+
+    public static Integer getArgSoraldCommitCollectorMode(JSAPResult arguments) {
         return arguments.getInt("segmentSize");
     }
 

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
@@ -68,6 +68,15 @@ public class RepairnatorConfig {
         SEGMENT
     }
 
+    /**
+     * DEFAULT - all given the commits iare analyzed
+     * VIOLATION_INTRODUCING - only commits that introduce new violations of the specified type are analyzed
+     */
+    public enum SORALD_COMMIT_COLLECTOR_MODE {
+        DEFAULT,
+        VIOLATION_INTRODUCING
+    }
+
     private String runId;
     private LauncherMode launcherMode = LauncherMode.REPAIR;
 
@@ -127,6 +136,7 @@ public class RepairnatorConfig {
     private int soraldMaxFixesPerRule;
     private int segmentSize;
     private SORALD_REPAIR_MODE soraldRepairMode;
+    private SORALD_COMMIT_COLLECTOR_MODE soraldCommitCollectorMode;
     private boolean measureSoraldTime;
 
     private PATCH_RANKING_MODE patchRankingMode;
@@ -761,6 +771,14 @@ public class RepairnatorConfig {
 
     public SORALD_REPAIR_MODE getSoraldRepairMode() {
         return this.soraldRepairMode;
+    }
+
+    public void setSoraldCommitCollectorMode(SORALD_COMMIT_COLLECTOR_MODE soraldCommitCollectorMode) {
+        this.soraldCommitCollectorMode = soraldCommitCollectorMode;
+    }
+
+    public SORALD_COMMIT_COLLECTOR_MODE getSoraldCommitCollectorMode() {
+        return this.soraldCommitCollectorMode;
     }
 
     public void setSoraldMaxFixesPerRule(int soraldMaxFixesPerRule) {


### PR DESCRIPTION
This PR adds the option to fix only the commits that introduce new SonarQube violations of the specified rule-type. In this mode, other commits are simply ignored.