### PR TITLE
feat: option to fix only commits that introduce new SonarQube violations

### DIFF
--- a/doc/repair-tools.md
+++ b/doc/repair-tools.md
@@ -57,7 +57,7 @@ Additional parameters:
 * `--soraldRepairMode`: DEFAULT - the normal mode of Sorald, where the entire project is inputted. SEGMENT - the input project is sliced into smaller fixed-size segments.
 * `--soraldMaxFixesPerRule`: specify the upper bound of the number of warning fixes.
 * `--segmentSize`: the number of files per segment if Sorald runs in Segment mode.
-
+* `--soraldCommitCollectorMode`: DEFAULT - all commits are analyzed. VIOLATION_INTRODUCING - only commits that are introducing new violations of the specified types are analyzed.
 ## Sequencer
 
 [Sequencer](http://arxiv.org/pdf/1901.01808) is a repair tool based on machine learning with sequence-to-sequence. You run it as follows:

--- a/src/docker-images/pipeline-dockerimage/Dockerfile
+++ b/src/docker-images/pipeline-dockerimage/Dockerfile
@@ -6,9 +6,9 @@ COPY z3_for_linux /root/
 COPY projects_to_ignore.txt /root/
 COPY logback.xml /root/
 COPY configure_git.sh /root/
-COPY build_repairnator.sh /root/
+# COPY build_repairnator.sh /root/
 COPY pipeline_launcher.sh /root/
-COPY ODSmodel.bin /root/
+# COPY ODSmodel.bin /root/
 
 RUN apt-get update 
 RUN apt-get install xmlstarlet apt-utils cloc libgomp1 -y
@@ -17,7 +17,8 @@ RUN echo `xmlstarlet sel -t -v '//latest' maven-metadata.xml` > /root/version.in
 RUN chmod +x /root/*.sh
 RUN echo "Europe/Paris" > /etc/timezone 
 RUN /root/configure_git.sh 
-RUN /root/build_repairnator.sh
+# RUN /root/build_repairnator.sh
+COPY repairnator-pipeline.jar /root/
 
 ENV M2_HOME=$MAVEN_HOME
 ENV GITHUB_OAUTH=
@@ -51,4 +52,4 @@ ENV ACTIVEMQ_USERNAME=
 ENV ACTIVEMQ_PASSWORD=
 
 WORKDIR /root
-ENTRYPOINT /root/pipeline_launcher.sh
+CMD /root/pipeline_launcher.sh

--- a/src/docker-images/pipeline-dockerimage/pipeline_launcher.sh
+++ b/src/docker-images/pipeline-dockerimage/pipeline_launcher.sh
@@ -10,7 +10,31 @@ function ca {
   fi
 }
 
-args="`ca --dbhost $MONGODB_HOST``ca --dbname $MONGODB_NAME``ca --smtpServer $SMTP_SERVER``ca --smtpPort $SMTP_PORT``ca --smtpUsername $SMTP_USERNAME``ca --smtpPassword $SMTP_PASSWORD``ca --notifyto $NOTIFY_TO``ca --githubUserName $GITHUB_USERNAME``ca --githubUserEmail $GITHUB_USEREMAIL``ca --experimentalPluginRepoList $EXPERIMENTAL_PLUGIN_REPOS``ca --listenermode $LISTEN_MODE``ca --activemqurl $ACTIVEMQ_URL``ca --activemqlistenqueuename $ACTIVEMQ_LISTEN_QUEUE``ca --activemqusername $ACTIVEMQ_USERNAME``ca --activemqpassword $ACTIVEMQ_PASSWORD``ca --pushurl $PUSH_URL``ca --jtravisendpoint $TRAVIS_ENDPOINT``ca --travistoken $TRAVIS_TOKEN`"
+args="`ca --dbhost $MONGODB_HOST`\
+`ca --dbname $MONGODB_NAME`\
+`ca --smtpServer $SMTP_SERVER`\
+`ca --smtpPort $SMTP_PORT`\
+`ca --smtpUsername $SMTP_USERNAME`\
+`ca --smtpPassword $SMTP_PASSWORD`\
+`ca --notifyto $NOTIFY_TO`\
+`ca --launcherChoice NEW`\
+`ca --launcherMode GIT_REPOSITORY`\
+`ca --githubUserName $GITHUB_USERNAME`\
+`ca --githubUserEmail $GITHUB_USEREMAIL`\
+`ca --experimentalPluginRepoList $EXPERIMENTAL_PLUGIN_REPOS`\
+`ca --listenermode $LISTEN_MODE`\
+`ca --activemqurl $ACTIVEMQ_URL`\
+`ca --activemqlistenqueuename $ACTIVEMQ_LISTEN_QUEUE`\
+`ca --activemqusername $ACTIVEMQ_USERNAME`\
+`ca --activemqpassword $ACTIVEMQ_PASSWORD`\
+`ca --pushurl $PUSH_URL`\
+`ca --jtravisendpoint $TRAVIS_ENDPOINT`\
+`ca --travistoken $TRAVIS_TOKEN`\
+`ca --sonarRules $SORALD_SONAR_RULES`\
+`ca --soraldRepairMode $SORALD_REPAIR_MODE`\
+`ca --soraldSegmentSize $SORALD_SEGMENT_SIZE`\
+`ca --soraldMaxFixesPerRule $SORALD_MAX_FIXES_PER_RULE`\
+`ca --soraldSkipPR $SORALD_SKIP_PR`"
 
 if [[ "$CREATE_PR" == 1 ]]; then
   args="$args --createPR"
@@ -38,7 +62,7 @@ LOCAL_REPAIR_MODE=repair
 
 
 # Github XOR Travis
-if [[ -n "$GITHUB_URL" ]] && [[ -s "$GITHUB_SHA" ]]; then
+if [[ -n "$GITHUB_URL" ]] && [[ -n "$GITHUB_SHA" ]]; then
   echo "adding GitHub mode variables"
   args="$args --gitrepo --gitrepourl $GITHUB_URL --gitrepoidcommit $GITHUB_SHA"
 elif [[ -n "$BUILD_ID" ]]; then
@@ -93,4 +117,4 @@ export GITHUB_USEREMAIL=
 
 echo "Execute pipeline with following supplementary args: $args"
 
-java -cp $JAVA_HOME/lib/tools.jar:repairnator-pipeline.jar -Dlogback.configurationFile=/root/logback.xml fr.inria.spirals.repairnator.pipeline.Launcher -d --runId $LOCAL_RUN_ID -o $LOCAL_OUTPUT --ghOauth $LOCAL_GITHUB_OAUTH --repairTools $REPAIR_TOOLS $args
+java -cp $JAVA_HOME/lib/tools.jar:repairnator-pipeline.jar -Dlogback.configurationFile=/root/logback.xml fr.inria.spirals.repairnator.pipeline.Launcher -d --runId $LOCAL_RUN_ID -o $LOCAL_OUTPUT --ghOauth $LOCAL_GITHUB_OAUTH --repairTools $REPAIR_TOOLS $args -d

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
@@ -113,6 +113,8 @@ public class LauncherUtils {
         jsap.registerParameter(LauncherUtils.defineArgSoraldRepairMode());
         // --soraldSegmentSize
         jsap.registerParameter(LauncherUtils.defineArgSoraldSegmentSize());
+        // --soraldCommitCollectorMode
+        jsap.registerParameter(LauncherUtils.defineArgSoraldCommitCollectorMode());
         // --soraldMaxFixesPerRule
         jsap.registerParameter(LauncherUtils.defineArgSoraldMaxFixesPerRule());
         // --soraldSkipPR
@@ -869,6 +871,19 @@ public class LauncherUtils {
 
     public static Integer getArgSoraldSegmentSize(JSAPResult arguments) {
         return arguments.getInt("soraldSegmentSize");
+    }
+
+    public static FlaggedOption defineArgSoraldCommitCollectorMode() {
+        FlaggedOption opt = new FlaggedOption("soraldCommitCollectorMode");
+        opt.setLongFlag("soraldCommitCollectorMode");
+        opt.setStringParser(JSAP.STRING_PARSER);
+        opt.setDefault("200");
+        opt.setHelp("Segment size for the segment repair.");
+        return opt;
+    }
+
+    public static Integer getArgSoraldCommitCollectorMode(JSAPResult arguments) {
+        return arguments.getInt("segmentSize");
     }
 
     public static FlaggedOption defineArgSoraldMaxFixesPerRule() {

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
@@ -111,10 +111,12 @@ public class LauncherUtils {
         jsap.registerParameter(LauncherUtils.defineArgSonarRules());
         // --soraldRepairMode
         jsap.registerParameter(LauncherUtils.defineArgSoraldRepairMode());
-        // --segmentSize
-        jsap.registerParameter(LauncherUtils.defineArgSegmentSize());
+        // --soraldSegmentSize
+        jsap.registerParameter(LauncherUtils.defineArgSoraldSegmentSize());
         // --soraldMaxFixesPerRule
         jsap.registerParameter(LauncherUtils.defineArgSoraldMaxFixesPerRule());
+        // --soraldSkipPR
+        jsap.registerParameter(LauncherUtils.defineArgSoraldSkipPR());
 
         // --bears
         jsap.registerParameter(LauncherUtils.defineArgBearsMode());
@@ -211,9 +213,10 @@ public class LauncherUtils {
         }
 
         config.setSonarRules(Arrays.stream(LauncherUtils.getArgSonarRules(arguments).split(",")).distinct().toArray(String[]::new));
-        config.setSegmentSize(LauncherUtils.getArgSegmentSize(arguments));
+        config.setSoraldSegmentSize(LauncherUtils.getArgSoraldSegmentSize(arguments));
         config.setSoraldRepairMode(RepairnatorConfig.SORALD_REPAIR_MODE.valueOf(LauncherUtils.getArgSoraldRepairMode(arguments)));
         config.setSoraldMaxFixesPerRule(LauncherUtils.getArgSoraldMaxFixesPerRule(arguments));
+        config.setSoraldSkipPR(LauncherUtils.getArgSoraldSkipPR(arguments));
 
         config.setPatchRankingMode(LauncherUtils.getArgPatchRankingMode(arguments));
     }
@@ -855,17 +858,17 @@ public class LauncherUtils {
         return arguments.getString("soraldRepairMode");
     }
 
-    public static FlaggedOption defineArgSegmentSize() {
-        FlaggedOption opt = new FlaggedOption("segmentSize");
-        opt.setLongFlag("segmentSize");
+    public static FlaggedOption defineArgSoraldSegmentSize() {
+        FlaggedOption opt = new FlaggedOption("soraldSegmentSize");
+        opt.setLongFlag("soraldSegmentSize");
         opt.setStringParser(JSAP.INTEGER_PARSER);
         opt.setDefault("200");
         opt.setHelp("Segment size for the segment repair.");
         return opt;
     }
 
-    public static Integer getArgSegmentSize(JSAPResult arguments) {
-        return arguments.getInt("segmentSize");
+    public static Integer getArgSoraldSegmentSize(JSAPResult arguments) {
+        return arguments.getInt("soraldSegmentSize");
     }
 
     public static FlaggedOption defineArgSoraldMaxFixesPerRule() {
@@ -879,6 +882,18 @@ public class LauncherUtils {
 
     public static Integer getArgSoraldMaxFixesPerRule(JSAPResult arguments) {
         return arguments.getInt("soraldMaxFixesPerRule");
+    }
+
+    public static Switch defineArgSoraldSkipPR() {
+        Switch opt = new Switch("soraldSkipPR");
+        opt.setLongFlag("soraldSkipPR");
+        opt.setDefault("false");
+        opt.setHelp("Create fork and push but not a PR.");
+        return opt;
+    }
+
+    public static Boolean getArgSoraldSkipPR(JSAPResult arguments) {
+        return arguments.getBoolean("soraldSkipPR");
     }
 
     public static FlaggedOption defineArgPatchRankingMode() {

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
@@ -68,6 +68,15 @@ public class RepairnatorConfig {
         SEGMENT
     }
 
+    /**
+     * DEFAULT - all given the commits iare analyzed
+     * VIOLATION_INTRODUCING - only commits that introduce new violations of the specified type are analyzed
+     */
+    public enum SORALD_COMMIT_COLLECTOR_MODE {
+        DEFAULT,
+        VIOLATION_INTRODUCING
+    }
+
     private String runId;
     private LauncherMode launcherMode = LauncherMode.REPAIR;
 
@@ -127,6 +136,7 @@ public class RepairnatorConfig {
     private int soraldMaxFixesPerRule;
     private int soraldSegmentSize;
     private SORALD_REPAIR_MODE soraldRepairMode;
+    private SORALD_COMMIT_COLLECTOR_MODE soraldCommitCollectorMode;
     private boolean measureSoraldTime;
     private boolean soraldSkipPR;
 
@@ -762,6 +772,14 @@ public class RepairnatorConfig {
 
     public SORALD_REPAIR_MODE getSoraldRepairMode() {
         return this.soraldRepairMode;
+    }
+
+    public void setSoraldCommitCollectorMode(SORALD_COMMIT_COLLECTOR_MODE soraldCommitCollectorMode) {
+        this.soraldCommitCollectorMode = soraldCommitCollectorMode;
+    }
+
+    public SORALD_COMMIT_COLLECTOR_MODE getSoraldCommitCollectorMode() {
+        return this.soraldCommitCollectorMode;
     }
 
     public void setSoraldMaxFixesPerRule(int soraldMaxFixesPerRule) {

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
@@ -125,9 +125,10 @@ public class RepairnatorConfig {
     private String[] sonarRules;
     private boolean isStaticAnalysis;
     private int soraldMaxFixesPerRule;
-    private int segmentSize;
+    private int soraldSegmentSize;
     private SORALD_REPAIR_MODE soraldRepairMode;
     private boolean measureSoraldTime;
+    private boolean soraldSkipPR;
 
     private PATCH_RANKING_MODE patchRankingMode;
     
@@ -747,12 +748,12 @@ public class RepairnatorConfig {
         return this.isStaticAnalysis;
     }
 
-    public void setSegmentSize(int segmentSize) {
-        this.segmentSize = segmentSize;
+    public void setSoraldSegmentSize(int soraldSegmentSize) {
+        this.soraldSegmentSize = soraldSegmentSize;
     }
 
-    public int getSegmentSize() {
-        return this.segmentSize;
+    public int getSoraldSegmentSize() {
+        return this.soraldSegmentSize;
     }
 
     public void setSoraldRepairMode(SORALD_REPAIR_MODE soraldRepairMode) {
@@ -968,5 +969,13 @@ public class RepairnatorConfig {
 
     public void setTravisToken(String travisToken) {
         this.travisToken = travisToken;
+    }
+
+    public void setSoraldSkipPR(boolean soraldSkipPR) {
+        this.soraldSkipPR = soraldSkipPR;
+    }
+
+    public boolean isSoraldSkipPR() {
+        return soraldSkipPR;
     }
 }

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/dockerpool/RunnablePipelineContainer.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/dockerpool/RunnablePipelineContainer.java
@@ -93,6 +93,7 @@ public class RunnablePipelineContainer implements Runnable {
         this.envValues.add("OUTPUT="+output);
         this.envValues.add("TRAVIS_ENDPOINT="+this.repairnatorConfig.getJTravisEndpoint());
         this.envValues.add("TRAVIS_TOKEN="+this.repairnatorConfig.getTravisToken());
+
         if (this.repairnatorConfig.isCreatePR()) {
             this.envValues.add("CREATE_PR=1");
         }
@@ -102,7 +103,10 @@ public class RunnablePipelineContainer implements Runnable {
             this.envValues.add("SMTP_TLS=0");
         }
 
-        if (this.repairnatorConfig.getLauncherMode() == LauncherMode.REPAIR || this.repairnatorConfig.getLauncherMode() == LauncherMode.CHECKSTYLE) {
+        if (this.repairnatorConfig.getLauncherMode() == LauncherMode.REPAIR ||
+                this.repairnatorConfig.getLauncherMode() == LauncherMode.CHECKSTYLE ||
+                this.repairnatorConfig.getLauncherMode() == LauncherMode.GIT_REPOSITORY
+        ) {
             this.envValues.add("REPAIR_TOOLS=" + StringUtils.join(this.repairnatorConfig.getRepairTools(), ","));
         }
 
@@ -113,6 +117,15 @@ public class RunnablePipelineContainer implements Runnable {
             this.envValues.add("SEQUENCER_BEAM_SIZE=" + sequencerConfig.beamSize);
             this.envValues.add("SEQUENCER_TIMEOUT=" + sequencerConfig.timeout);
             this.envValues.add("SEQUENCER_ODS_PATH=" + sequencerConfig.ODSPath);
+        }
+
+        if (this.repairnatorConfig.getRepairTools().contains("Sorald")){
+            this.envValues.add("SORALD_REPAIR_MODE=" + repairnatorConfig.getSoraldRepairMode());
+            this.envValues.add("SORALD_MAX_FIXES_PER_RULE=" + repairnatorConfig.getSoraldMaxFixesPerRule());
+            this.envValues.add("SORALD_SONAR_RULES=" + String.join(",", repairnatorConfig.getSonarRules()));
+            this.envValues.add("SORALD_SEGMENT_SIZE=" + repairnatorConfig.getSoraldSegmentSize());
+            this.envValues.add("SORALD_SKIP_PR=" + repairnatorConfig.isSoraldSkipPR());
+            this.envValues.add("SORALD_STATIC_ANALYSIS=" + repairnatorConfig.isStaticAnalysis());
         }
     }
 
@@ -158,11 +171,11 @@ public class RunnablePipelineContainer implements Runnable {
                             .from(logsVolume)
                             .to("/var/log/")
                             .build())
-                    .appendBinds(HostConfig.Bind
-                            .builder()
-                            .from(ODSVolume)
-                            .to(SequencerConfig.getInstance().ODSPath)
-                            .build())
+//                    .appendBinds(HostConfig.Bind
+//                            .builder()
+//                            .from(ODSVolume)
+//                            .to(SequencerConfig.getInstance().ODSPath)
+//                            .build())
                     .build();
 
             // we specify the complete configuration of the container

--- a/src/repairnator-pipeline/build-local.sh
+++ b/src/repairnator-pipeline/build-local.sh
@@ -1,0 +1,7 @@
+cd ../repairnator-core
+mvn install -DskipTests
+cd ../repairnator-pipeline
+mvn package -DskipTests
+cp target/repairnator-realtime-3.3-SNAPSHOT-jar-with-dependencies.jar ../docker-images/pipeline-dockerimage/
+cd ../docker-images/pipeline-dockerimage/
+docker build . -t repairnator/pipeline:sorald

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/Launcher.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/Launcher.java
@@ -1,3 +1,4 @@
+
 package fr.inria.spirals.repairnator.pipeline;
 
 import com.martiansoftware.jsap.FlaggedOption;

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/Sorald.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/Sorald.java
@@ -209,7 +209,8 @@ public class Sorald extends AbstractRepairStep {
                         Constants.ARG_TEMP_DIR,
                         Files.createTempDirectory("mining_tmp").toString(),
                         Constants.ARG_STATS_OUTPUT_FILE,
-                        stats.getPath()
+                        stats.getPath(),
+                        Constants.ARG_HANDLED_RULES
                 };
 
         Main.main(args);

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/Sorald.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/Sorald.java
@@ -4,10 +4,13 @@ import fr.inria.spirals.repairnator.process.inspectors.RepairPatch;
 import fr.inria.spirals.repairnator.process.step.StepStatus;
 import fr.inria.spirals.repairnator.process.git.GitHelper;
 
+import org.apache.commons.collections.map.HashedMap;
+import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.Git;
 
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,14 +19,21 @@ import java.nio.file.Files;
 import java.lang.StringBuilder;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.*;
 import java.net.URISyntaxException;
-import java.util.Date;
+import java.util.stream.Collectors;
 
 import fr.inria.spirals.repairnator.utils.DateUtils;
 import fr.inria.spirals.repairnator.config.RepairnatorConfig;
 
 import org.apache.commons.lang3.text.StrSubstitutor;
 
+import org.eclipse.jgit.lib.ObjectId;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import sorald.Constants;
 import sorald.Main;
 
 public class Sorald extends AbstractRepairStep {
@@ -50,13 +60,25 @@ public class Sorald extends AbstractRepairStep {
         this.getLogger().info("Entrance in Sorald step...");
         String pathToRepoDir = this.getInspector().getRepoLocalPath();
 
+        Set<String> introducedViolationTypes = new HashSet<String>();
+        try {
+            introducedViolationTypes = getIntroducedViolationTypes(pathToRepoDir);
+        } catch (Exception e) {
+            return StepStatus.buildSkipped(this, "Error while mining with Sorald");
+        }
+
         Map<String, String> values = new HashMap<String, String>();
-                values.put("tools", String.join(",", this.getConfig().getRepairTools()));
-                StrSubstitutor sub = new StrSubstitutor(values, "%(", ")");
+        values.put("tools", String.join(",", this.getConfig().getRepairTools()));
+        StrSubstitutor sub = new StrSubstitutor(values, "%(", ")");
         StringBuilder prTextBuilder = new StringBuilder().append("This PR fixes the violations for the following Sorald rules: \n");
         String newBranchName = "repairnator-patch-" + DateUtils.formatFilenameDate(new Date());
 
         for (String rule : RepairnatorConfig.getInstance().getSonarRules()) {
+            if(RepairnatorConfig.getInstance().getSoraldCommitCollectorMode()
+                    == RepairnatorConfig.SORALD_COMMIT_COLLECTOR_MODE.VIOLATION_INTRODUCING
+                    && !introducedViolationTypes.contains(rule))
+                continue;
+
             this.getLogger().info("Repo: " + pathToRepoDir);
             this.getLogger().info("Try to repair rule " + rule);
             String[] args = new String[]{
@@ -70,13 +92,13 @@ public class Sorald extends AbstractRepairStep {
                             "--maxFilesPerSegment","" + RepairnatorConfig.getInstance().getSoraldSegmentSize()};
             try {
                 Main.main(args);
-            } catch(Exception e) {
-                return StepStatus.buildSkipped(this,"Error while repairing with Sorald");
+            } catch (Exception e) {
+                return StepStatus.buildSkipped(this, "Error while repairing with Sorald");
             }
 
             File patchDir = new File(RepairnatorConfig.getInstance().getWorkspacePath() + File.separator + "SoraldGitPatches");
 
-            
+
             if (patchDir.exists()) {
                 File[] patchFiles = patchDir.listFiles();
                 this.getLogger().info("Number of patches found: " + patchFiles.length);
@@ -88,12 +110,12 @@ public class Sorald extends AbstractRepairStep {
                             RepairPatch repairPatch = new RepairPatch(this.getRepairToolName(), "", content);
                             repairPatches.add(repairPatch);
                         } catch (Exception e) {
-                            return StepStatus.buildSkipped(this,"Error while retrieving patches");
+                            return StepStatus.buildSkipped(this, "Error while retrieving patches");
                         }
                         patchFile.delete();
                     }
                     prTextBuilder.append(RULE_LINK_TEMPLATE).append(rule + "\n");
-                    this.performApplyPatch(repairPatches,repairPatches.size(),rule,newBranchName);
+                    this.performApplyPatch(repairPatches, repairPatches.size(), rule, newBranchName);
                     if (!patchFound) {
                         patchFound = true;
                         this.allPatches.addAll(repairPatches); // Only mailing patches will only support single rule repair - FIXME
@@ -107,7 +129,7 @@ public class Sorald extends AbstractRepairStep {
             return StepStatus.buildPatchNotFound(this);
         }
 
-        this.getInspector().getJobStatus().addPatches(this.getRepairToolName(), allPatches);   
+        this.getInspector().getJobStatus().addPatches(this.getRepairToolName(), allPatches);
         if (this.getConfig().isCreatePR()) {
             this.setPrText(prTextBuilder.toString());
             try {
@@ -118,15 +140,62 @@ public class Sorald extends AbstractRepairStep {
                 }
             } catch(IOException | GitAPIException | URISyntaxException e) {
                 e.printStackTrace();
-                return StepStatus.buildSkipped(this,"Error while creating pull request");
+                return StepStatus.buildSkipped(this, "Error while creating pull request");
             }
-        } 
+        }
         System.out.println("All patches : " + allPatches.size());
         this.notify(allPatches);
         return StepStatus.buildSuccess(this);
     }
 
-    private void performApplyPatch(List<RepairPatch> patchList,int patchNbsLimit,String ruleNumber,String newBranchName) {
+    private Set<String> getIntroducedViolationTypes(String pathToRepoDir)
+            throws IOException, GitAPIException, ParseException {
+        File copyRepoDir = new File(Files.createTempDirectory("repo_copy").toString());
+        FileUtils.copyDirectory(new File(pathToRepoDir), copyRepoDir);
+
+        Map<String, Integer> lastRuleToCnt = countRuleViolations(copyRepoDir);
+
+        Git git = Git.open(copyRepoDir);
+        ObjectId previousCommitId = git.getRepository().resolve("HEAD^");
+        git.checkout().setName(previousCommitId.getName()).call();
+
+        Map<String, Integer> previousRuleToCnt = countRuleViolations(copyRepoDir);
+
+        return lastRuleToCnt.entrySet().stream().filter(x -> x.getValue() > previousRuleToCnt.get(x.getKey()))
+                .map(x -> x.getKey()).collect(Collectors.toSet());
+    }
+
+    private Map<String, Integer> countRuleViolations(File repoDir) throws IOException, ParseException {
+        Map<String, Integer> ret = new HashMap<String, Integer>();
+
+        File stats = new File(Files.createTempDirectory("mining_stats.json").toString());
+        String[] baseArgs =
+                new String[]{
+                        Constants.MINE_COMMAND_NAME,
+                        Constants.ARG_ORIGINAL_FILES_PATH,
+                        repoDir.getPath(),
+                        Constants.ARG_TEMP_DIR,
+                        Files.createTempDirectory("mining_tmp").toString(),
+                        Constants.ARG_STATS_OUTPUT_FILE,
+                        stats.getPath()
+                };
+
+        JSONParser parser = new JSONParser();
+        JSONObject jo = (JSONObject) parser.parse(new FileReader(stats));
+        JSONArray ja = (JSONArray) jo.get("minedRules");
+        for (int i = 0; i < ja.size(); i++) {
+            jo = (JSONObject) ja.get(i);
+            int violationCnt = Integer.parseInt(jo.get("nbFoundWarnings").toString());
+            if (violationCnt > 0) {
+                String rule = jo.get("ruleKey").toString();
+                ret.put(rule, violationCnt);
+            }
+        }
+
+        return ret;
+    }
+
+    private void performApplyPatch(List<RepairPatch> patchList, int patchNbsLimit, String ruleNumber, String newBranchName) {
         if (!patchList.isEmpty()) {
             this.getInspector().getJobStatus().setHasBeenPatched(true);
             List<File> serializedPatches = null;
@@ -144,7 +213,7 @@ public class Sorald extends AbstractRepairStep {
                         }
                         this.forkedGit = this.createGitBranch4Push(newBranchName);
                     }
-                    this.applyPatches4Sonar(this.forkedGit,serializedPatches,patchNbsLimit,ruleNumber);
+                    this.applyPatches4Sonar(this.forkedGit, serializedPatches, patchNbsLimit, ruleNumber);
                 } catch (IOException | GitAPIException | URISyntaxException e) {
                     this.addStepError("Error while creating the PR", e);
                 }
@@ -155,16 +224,16 @@ public class Sorald extends AbstractRepairStep {
         }
     }
 
-    private void applyPatches4Sonar(Git git,List<File> patchList,int nbPatch,String ruleNumber) throws IOException, GitAPIException, URISyntaxException {
+    private void applyPatches4Sonar(Git git, List<File> patchList, int nbPatch, String ruleNumber) throws IOException, GitAPIException, URISyntaxException {
         for (int i = 0; i < nbPatch && i < patchList.size(); i++) {
             File patch = patchList.get(i);
             ProcessBuilder processBuilder = new ProcessBuilder("git", "apply", patch.getAbsolutePath())
-                        .directory(new File(this.getInspector().getRepoLocalPath())).inheritIO();
+                    .directory(new File(this.getInspector().getRepoLocalPath())).inheritIO();
 
             try {
                 Process p = processBuilder.start();
                 p.waitFor();
-            } catch (InterruptedException|IOException e) {
+            } catch (InterruptedException | IOException e) {
                 this.addStepError("Error while executing git command to apply patch " + patch.getPath(), e);
             }
         }

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineArgs.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineArgs.java
@@ -10,7 +10,6 @@ import fr.inria.spirals.repairnator.TravisLauncherUtils;
 import fr.inria.spirals.repairnator.config.RepairnatorConfig;
 import fr.inria.spirals.repairnator.utils.Utils;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -159,8 +158,8 @@ public class TestPipelineArgs {
         assertEquals(defaultSoraldRepairMode.name(), LauncherUtils.getArgSoraldRepairMode(arguments));
         assertEquals(defaultSoraldRepairMode, config.getSoraldRepairMode());
         Integer defaultSegmentSize = 200;
-        assertEquals(defaultSegmentSize, LauncherUtils.getArgSegmentSize(arguments));
-        assertEquals((int) defaultSegmentSize, config.getSegmentSize());
+        assertEquals(defaultSegmentSize, LauncherUtils.getArgSoraldSegmentSize(arguments));
+        assertEquals((int) defaultSegmentSize, config.getSoraldSegmentSize());
         Integer defaultMaxFixesPerRule = 2000;
         assertEquals(defaultMaxFixesPerRule, LauncherUtils.getArgSoraldMaxFixesPerRule(arguments));
         assertEquals((int) defaultMaxFixesPerRule, config.getSoraldMaxFixesPerRule());

--- a/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestGithubScanner.java
+++ b/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestGithubScanner.java
@@ -64,5 +64,4 @@ public class TestGithubScanner {
         assertFalse(commits.stream().anyMatch(x -> x.getCommitId().equals("290bdc01884f7c9bf2140a7c66d22ca72fe50fbb")));
         assertTrue(commits.stream().anyMatch(x -> x.getCommitId().equals("e3456813fdcca1ed5075c0fb72b0bcbc9524e791")));
     }
-
 }


### PR DESCRIPTION
This PR adds the option to fix only the commits that introduce new SonarQube violations of the specified rule-type. In this mode, other commits are simply ignored.