### PR TITLE
Downgrade Sorald's version so that Repairnator compiles again on Java 8

### DIFF
--- a/src/repairnator-pipeline/pom.xml
+++ b/src/repairnator-pipeline/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>se.kth.castor</groupId>
             <artifactId>sorald</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>1.1-20200928.114859-2</version>
         </dependency>
         <dependency>
             <groupId>fr.inria.repairnator</groupId>
@@ -124,7 +124,6 @@
             <artifactId>activemq-core</artifactId>
             <version>5.7.0</version>
         </dependency>
-        
     </dependencies>
 
     <properties>


### PR DESCRIPTION
Sorald no longer supports Java 8 (see https://github.com/SpoonLabs/sorald/issues/371

This change is meant to be temporary and be reverted after we drop support for Java 8.