### PR TITLE
feat; Add source classes information to errors.

### DIFF
--- a/src/repairnator-pipeline/pom.xml
+++ b/src/repairnator-pipeline/pom.xml
@@ -124,6 +124,11 @@
             <artifactId>activemq-core</artifactId>
             <version>5.7.0</version>
         </dependency>
+        <dependency>
+            <groupId>exceptionparser</groupId>
+            <artifactId>exceptionparser</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/components/RunInspector4DefaultGit.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/components/RunInspector4DefaultGit.java
@@ -59,10 +59,10 @@ public class RunInspector4DefaultGit extends IRunInspector{
                 cloneRepo
                     .addNextStep(new BuildProject(inspector))
                     .addNextStep(new TestProject(inspector))
-                    .addNextStep(new GatherTestInformation(inspector, true, new BuildShouldFail(), false))                    
                     .addNextStep(new ComputeClasspath(inspector, false))
                     .addNextStep(new ComputeSourceDir(inspector, false, false))
-                    .addNextStep(new ComputeTestDir(inspector, false));
+                    .addNextStep(new ComputeTestDir(inspector, true))
+                    .addNextStep(new GatherTestInformation(inspector, true, new BuildShouldFail(), false));
             }
             
             cloneRepo.addNextStep(new GitRepositoryInitRepoToPush(inspector));

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/components/RunInspector4DefaultTravis.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/components/RunInspector4DefaultTravis.java
@@ -56,10 +56,10 @@ public class RunInspector4DefaultTravis extends IRunInspector{
                 cloneRepo
                     .addNextStep(new BuildProject(inspector))
                     .addNextStep(new TestProject(inspector))
-                    .addNextStep(new GatherTestInformation(inspector, true, new BuildShouldFail(), false))
                     .addNextStep(new ComputeClasspath(inspector, false))
                     .addNextStep(new ComputeSourceDir(inspector, false, false))
-                    .addNextStep(new ComputeTestDir(inspector, false));
+                    .addNextStep(new ComputeTestDir(inspector, true))
+                    .addNextStep(new GatherTestInformation(inspector, true, new BuildShouldFail(), false));
             }
            
             cloneRepo.addNextStep(new InitRepoToPush(inspector));

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/components/RunInspector4Maven.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/components/RunInspector4Maven.java
@@ -50,10 +50,10 @@ public class RunInspector4Maven extends IRunInspector {
         }
 
         buildProjectStep.addNextStep(new TestProject(inspector))
-                .addNextStep(new GatherTestInformation(inspector, true, new BuildShouldFail(), false))
                 .addNextStep(new ComputeClasspath(inspector, false))
                 .addNextStep(new ComputeSourceDir(inspector, false, false))
-                .addNextStep(new ComputeTestDir(inspector, false))
+                .addNextStep(new ComputeTestDir(inspector, true))
+                .addNextStep(new GatherTestInformation(inspector, true, new BuildShouldFail(), false))
                 .addNextSteps(repairSteps);
 
         AbstractStep finalStep = new ComputeModules(inspector, false);

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/NPERepair.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/NPERepair.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonParser;
 import fr.inria.spirals.repairnator.process.inspectors.RepairPatch;
 import fr.inria.spirals.repairnator.process.step.StepStatus;
 import fr.inria.spirals.repairnator.process.maven.MavenHelper;
+import fr.inria.spirals.repairnator.process.testinformation.ErrorType;
 import fr.inria.spirals.repairnator.process.testinformation.FailureLocation;
 import fr.inria.spirals.repairnator.process.testinformation.FailureType;
 import org.apache.commons.io.FileUtils;
@@ -35,10 +36,10 @@ public class NPERepair extends AbstractRepairStep {
 
     private boolean isThereNPE() {
         for (FailureLocation failureLocation : this.getInspector().getJobStatus().getFailureLocations()) {
-            Map<String, List<FailureType>> errorsMap = failureLocation.getErroringMethodsAndFailures();
+            Map<String, List<ErrorType>> errorsMap = failureLocation.getErroringMethodsAndErrors();
             for (String method : errorsMap.keySet()) {
                 if (errorsMap.get(method).stream()
-                        .anyMatch((FailureType ft) -> ft.getFailureName().startsWith("java.lang.NullPointerException"))) {
+                        .anyMatch((ErrorType et) -> et.getName().startsWith("java.lang.NullPointerException"))) {
                     return true;
                 }
             }

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/NPERepairSafe.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/NPERepairSafe.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonParser;
 import fr.inria.spirals.repairnator.process.inspectors.RepairPatch;
 import fr.inria.spirals.repairnator.process.step.StepStatus;
 import fr.inria.spirals.repairnator.process.maven.MavenHelper;
+import fr.inria.spirals.repairnator.process.testinformation.ErrorType;
 import fr.inria.spirals.repairnator.process.testinformation.FailureLocation;
 import fr.inria.spirals.repairnator.process.testinformation.FailureType;
 import org.apache.commons.io.FileUtils;
@@ -37,10 +38,10 @@ public class NPERepairSafe extends AbstractRepairStep {
 
     private boolean isThereNPE() {
         for (FailureLocation failureLocation : this.getInspector().getJobStatus().getFailureLocations()) {
-            Map<String, List<FailureType>> errorsMap = failureLocation.getErroringMethodsAndFailures();
+            Map<String, List<ErrorType>> errorsMap = failureLocation.getErroringMethodsAndErrors();
             for (String method : errorsMap.keySet()) {
                 if (errorsMap.get(method).stream()
-                        .anyMatch((FailureType ft) -> ft.getFailureName().startsWith("java.lang.NullPointerException"))) {
+                        .anyMatch((ErrorType et) -> et.getName().startsWith("java.lang.NullPointerException"))) {
                     return true;
                 }
             }

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/BugType.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/BugType.java
@@ -7,6 +7,13 @@ public abstract class BugType {
     private String name;
     private String detail;
 
+
+    /**
+     * Abstract Class representing a type of bug that occurred during a test execution
+     *
+     * @param name The name of the type of bug
+     * @param detail The detailed message generated for this bug
+     */
     public BugType(String name, String detail) {
         this.name = name;
         this.detail = detail;

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/BugType.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/BugType.java
@@ -1,0 +1,44 @@
+package fr.inria.spirals.repairnator.process.testinformation;
+
+import java.util.Objects;
+
+public abstract class BugType {
+
+    private String name;
+    private String detail;
+
+    public BugType(String name, String detail) {
+        this.name = name;
+        this.detail = detail;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BugType bugType = (BugType) o;
+        return name.equals(bugType.name) && detail.equals(bugType.detail);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, detail);
+    }
+
+    @Override
+    public String toString() {
+        return "BugType{" +
+                "name='" + name + '\'' +
+                ", detail='" + detail + '\'' +
+                '}';
+    }
+
+}

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/ErrorType.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/ErrorType.java
@@ -7,12 +7,28 @@ import java.util.Set;
 
 public class ErrorType extends BugType {
 
+    /**
+     * Source class files where the error occurred.
+     */
     private Set<File> classFiles = new HashSet<>();
 
+    /**
+     * Source package files (directories) that contain classes where the error occurred or classes that are
+     * present in the stack trace of the error.
+     */
     private Set<File> packageFiles = new HashSet<>();
 
+    /**
+     * Source class files that are present in the error stack trace.
+     */
     private Set<File> stackFiles = new HashSet<>();
 
+    /**
+     * Class representing a type of error that occurred during a test execution
+     *
+     * @param name The name of the type of error
+     * @param detail The detailed message generated for this error
+     */
     public ErrorType(String name, String detail) {
         super(name, detail);
     }

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/ErrorType.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/ErrorType.java
@@ -1,0 +1,44 @@
+package fr.inria.spirals.repairnator.process.testinformation;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ErrorType extends BugType {
+
+    private Set<File> classFiles = new HashSet<>();
+
+    private Set<File> packageFiles = new HashSet<>();
+
+    private Set<File> stackFiles = new HashSet<>();
+
+    public ErrorType(String name, String detail) {
+        super(name, detail);
+    }
+
+    public Set<File> getClassFiles() {
+        return classFiles;
+    }
+
+    public Set<File> getPackageFiles() {
+        return packageFiles;
+    }
+
+    public Set<File> getStackFiles() {
+        return stackFiles;
+    }
+
+    public void addClassFiles(Collection<File> files) {
+        classFiles.addAll(files);
+    }
+
+    public void addPackageFiles(Collection<File> files) {
+        packageFiles.addAll(files);
+    }
+
+    public void addStackFiles(Collection<File> files) {
+        stackFiles.addAll(files);
+    }
+
+}

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/FailureLocation.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/FailureLocation.java
@@ -3,8 +3,10 @@ package fr.inria.spirals.repairnator.process.testinformation;
 import java.util.*;
 
 /**
- * Represent the location of a failure for Repair Tools. For now only Nopol is
- * using and it's repairing Test Classes, so we only consider that information
+ * Represents the location of a failure for Repair Tools.
+ *
+ * For now only Nopol and NPEFix are using this. We only consider Test Classes for failures, but we also consider
+ * Source Classes for errors.
  */
 public class FailureLocation {
     private String className;

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/FailureLocation.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/FailureLocation.java
@@ -9,7 +9,7 @@ import java.util.*;
 public class FailureLocation {
     private String className;
     private HashMap<String, List<FailureType>> failingMethods;
-    private HashMap<String, List<FailureType>> erroringMethods;
+    private HashMap<String, List<ErrorType>> erroringMethods;
     private int nbFailures;
     private int nbErrors;
 
@@ -32,12 +32,12 @@ public class FailureLocation {
         }
     }
 
-    public void addErroringMethod(String erroringMethod, FailureType failure) {
+    public void addErroringMethod(String erroringMethod, ErrorType error) {
         this.nbErrors++;
         if (this.erroringMethods.containsKey(erroringMethod)) {
-            this.erroringMethods.get(erroringMethod).add(failure);
+            this.erroringMethods.get(erroringMethod).add(error);
         } else {
-            this.erroringMethods.put(erroringMethod, Collections.singletonList(failure));
+            this.erroringMethods.put(erroringMethod, Collections.singletonList(error));
         }
     }
 
@@ -53,7 +53,7 @@ public class FailureLocation {
         return failingMethods;
     }
 
-    public Map<String, List<FailureType>> getErroringMethodsAndFailures() {
+    public Map<String, List<ErrorType>> getErroringMethodsAndErrors() {
         return erroringMethods;
     }
 

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/FailureType.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/FailureType.java
@@ -1,12 +1,16 @@
 package fr.inria.spirals.repairnator.process.testinformation;
 
-import java.util.Objects;
-
 /**
  * Created by urli on 08/02/2017.
  */
 public class FailureType extends BugType {
 
+    /**
+     * Class representing a type of failure that occurred during a test execution
+     *
+     * @param name The name of the type of failure
+     * @param detail The detailed message generated for this failure
+     */
     public FailureType(String name, String detail) {
         super(name, detail);
     }

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/FailureType.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/testinformation/FailureType.java
@@ -1,66 +1,14 @@
 package fr.inria.spirals.repairnator.process.testinformation;
 
+import java.util.Objects;
+
 /**
  * Created by urli on 08/02/2017.
  */
-public class FailureType {
+public class FailureType extends BugType {
 
-    private String failureName;
-    private String failureDetail;
-    private boolean isError;
-
-    public FailureType(String name, String detail, boolean isError) {
-        this.failureName = name;
-        this.failureDetail = detail;
-        this.isError = isError;
+    public FailureType(String name, String detail) {
+        super(name, detail);
     }
 
-    public String getFailureName() {
-        return failureName;
-    }
-
-    public boolean isError() {
-        return isError;
-    }
-
-    public String getFailureDetail() {
-        return failureDetail;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        FailureType that = (FailureType) o;
-
-        if (isError != that.isError) {
-            return false;
-        }
-        if (failureName != null ? !failureName.equals(that.failureName) : that.failureName != null) {
-            return false;
-        }
-        return failureDetail != null ? failureDetail.equals(that.failureDetail) : that.failureDetail == null;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = failureName != null ? failureName.hashCode() : 0;
-        result = 31 * result + (failureDetail != null ? failureDetail.hashCode() : 0);
-        result = 31 * result + (isError ? 1 : 0);
-        return result;
-    }
-
-    @Override
-    public String toString() {
-        return "FailureType{" +
-                "failureName='" + failureName + '\'' +
-                ", failureDetail='" + failureDetail + '\'' +
-                ", isError=" + isError +
-                '}';
-    }
 }

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/repair/TestNPERepair.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/repair/TestNPERepair.java
@@ -3,6 +3,9 @@ package fr.inria.spirals.repairnator.process.step.repair;
 import ch.qos.logback.classic.Level;
 import fr.inria.jtravis.entities.Build;
 import fr.inria.spirals.repairnator.BuildToBeInspected;
+import fr.inria.spirals.repairnator.process.step.paths.ComputeClasspath;
+import fr.inria.spirals.repairnator.process.step.paths.ComputeSourceDir;
+import fr.inria.spirals.repairnator.process.step.paths.ComputeTestDir;
 import fr.inria.spirals.repairnator.utils.Utils;
 import fr.inria.spirals.repairnator.config.RepairnatorConfig;
 import fr.inria.spirals.repairnator.process.files.FileHelper;
@@ -72,6 +75,9 @@ public class TestNPERepair {
 
         cloneStep.addNextStep(new CheckoutBuggyBuild(inspector, true))
                 .addNextStep(new TestProject(inspector))
+                .addNextStep(new ComputeClasspath(inspector, false))
+                .addNextStep(new ComputeSourceDir(inspector, false, false))
+                .addNextStep(new ComputeTestDir(inspector, true))
                 .addNextStep(new GatherTestInformation(inspector, true, new BuildShouldFail(), false))
                 .addNextStep(npeRepair);
 
@@ -80,8 +86,8 @@ public class TestNPERepair {
         assertThat(npeRepair.isShouldStop(), is(false));
 
         List<StepStatus> stepStatusList = inspector.getJobStatus().getStepStatuses();
-        assertThat(stepStatusList.size(), is(5));
-        StepStatus npeStatus = stepStatusList.get(4);
+        assertThat(stepStatusList.size(), is(8));
+        StepStatus npeStatus = stepStatusList.get(7);
         assertThat(npeStatus.getStep(), is(npeRepair));
 
         for (StepStatus stepStatus : stepStatusList) {


### PR DESCRIPTION
- Splits `FailureType` into `FailureType` and `ErrorType`
- Adds functionality to `GatherTestInformationStep` about the source classes where the error occurs, the packages where the error occurs and the classes in the stack trace of the error.

Closes #1185