### PR TITLE
fix: save patch on disk for NPERepair and AssertFixer

### DIFF
--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AbstractNPERepairStep.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AbstractNPERepairStep.java
@@ -158,9 +158,20 @@ public abstract class AbstractNPERepairStep extends AbstractRepairStep {
 
                         JsonElement diff = execution.getAsJsonObject().get("diff");
                         if (diff != null) {
+                            String path = execution.getAsJsonObject().getAsJsonArray("decisions")
+                                    .get(0).getAsJsonObject().getAsJsonObject("location").get("class")
+                                    .getAsString().replace(".","/") + ".java";
+                            for (File dir : this.getInspector().getJobStatus().getRepairSourceDir()) {
+                                String tmpPath = dir.getAbsolutePath() + "/" + path;
+                                if (new File(tmpPath).exists()) {
+                                    path = tmpPath;
+                                    break;
+                                }
+                            }
+
                             String content = diff.getAsString();
 
-                            RepairPatch repairPatch = new RepairPatch(this.getRepairToolName(), "", content);
+                            RepairPatch repairPatch = new RepairPatch(this.getRepairToolName(), path, content);
                             repairPatches.add(repairPatch);
                         } else {
                             this.addStepError("Error while parsing JSON path file: diff content is null.");

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AssertFixerRepair.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AssertFixerRepair.java
@@ -140,7 +140,17 @@ public class AssertFixerRepair extends AbstractRepairStep {
 
             if (result.isSuccess()) {
                 success = true;
-                RepairPatch patch = new RepairPatch(this.getRepairToolName(), result.getTestClass(), result.getDiff());
+
+                String path = result.getTestClass().replace(".","/") + ".java";
+                for (File dir : this.getInspector().getJobStatus().getTestDir()) {
+                    String tmpPath = dir.getAbsolutePath() + "/" + path;
+                    if (new File(tmpPath).exists()) {
+                        path = tmpPath;
+                        break;
+                    }
+                }
+
+                RepairPatch patch = new RepairPatch(this.getRepairToolName(), path, result.getDiff());
                 listPatches.add(patch);
             }
         }

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/repair/TestAssertFixerRepair.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/repair/TestAssertFixerRepair.java
@@ -98,6 +98,10 @@ public class TestAssertFixerRepair {
         }
         assertThat(allPatches.size(), is(8));
         assertThat(inspector.getJobStatus().getToolDiagnostic().get(assertFixerRepair.getRepairToolName()), notNullValue());
+
+        for (RepairPatch repairPatch : allPatches) {
+            assertTrue(new File(repairPatch.getFilePath()).exists());
+        }
     }
 
     private Build checkBuildAndReturn(long buildId, boolean isPR) {

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/repair/TestAstorRepair.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/repair/TestAstorRepair.java
@@ -100,6 +100,10 @@ public class TestAstorRepair {
 		List<RepairPatch> allPatches = inspector.getJobStatus().getAllPatches();
 		assertThat(allPatches.isEmpty(), is(false));
 		assertThat(inspector.getJobStatus().getToolDiagnostic().get(astorJKaliRepair.getRepairToolName()), notNullValue());
+
+		for (RepairPatch repairPatch : allPatches) {
+			assertTrue(new File(repairPatch.getFilePath()).exists());
+		}
 	}
 
 	@Test
@@ -145,6 +149,10 @@ public class TestAstorRepair {
 		assertThat(finalStatus, is("PATCHED"));
 		List<RepairPatch> allPatches = inspector.getJobStatus().getAllPatches();
 		assertThat(allPatches.isEmpty(), is(false));
+
+		for (RepairPatch repairPatch : allPatches) {
+			assertTrue(new File(repairPatch.getFilePath()).exists());
+		}
 	}
 
     private Build checkBuildAndReturn(long buildId, boolean isPR) {

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/repair/TestNPERepair.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/repair/TestNPERepair.java
@@ -102,6 +102,10 @@ public class TestNPERepair {
         List<RepairPatch> allPatches = inspector.getJobStatus().getAllPatches();
         assertThat(allPatches.size(), is(6));
         assertThat(inspector.getJobStatus().getToolDiagnostic().get(npeRepair.getRepairToolName()), notNullValue());
+
+        for (RepairPatch repairPatch : allPatches) {
+            assertTrue(new File(repairPatch.getFilePath()).exists());
+        }
     }
 
     @Test
@@ -151,6 +155,10 @@ public class TestNPERepair {
         List<RepairPatch> allPatches = inspector.getJobStatus().getAllPatches();
         assertThat(allPatches.size(), is(23));
         assertThat(inspector.getJobStatus().getToolDiagnostic().get(npeRepair.getRepairToolName()), notNullValue());
+
+        for (RepairPatch repairPatch : allPatches) {
+            assertTrue(new File(repairPatch.getFilePath()).exists());
+        }
     }
 
     @Test
@@ -200,6 +208,10 @@ public class TestNPERepair {
         List<RepairPatch> allPatches = inspector.getJobStatus().getAllPatches();
         assertThat(allPatches.size(), is(23));
         assertThat(inspector.getJobStatus().getToolDiagnostic().get(npeRepair.getRepairToolName()), notNullValue());
+
+        for (RepairPatch repairPatch : allPatches) {
+            assertTrue(new File(repairPatch.getFilePath()).exists());
+        }
     }
 
     @Test
@@ -249,6 +261,10 @@ public class TestNPERepair {
         List<RepairPatch> allPatches = inspector.getJobStatus().getAllPatches();
         assertThat(allPatches.size(), is(23));
         assertThat(inspector.getJobStatus().getToolDiagnostic().get(npeRepair.getRepairToolName()), notNullValue());
+
+        for (RepairPatch repairPatch : allPatches) {
+            assertTrue(new File(repairPatch.getFilePath()).exists());
+        }
     }
 
     @Test
@@ -298,6 +314,10 @@ public class TestNPERepair {
         List<RepairPatch> allPatches = inspector.getJobStatus().getAllPatches();
         assertThat(allPatches.size(), is(23));
         assertThat(inspector.getJobStatus().getToolDiagnostic().get(npeRepair.getRepairToolName()), notNullValue());
+
+        for (RepairPatch repairPatch : allPatches) {
+            assertTrue(new File(repairPatch.getFilePath()).exists());
+        }
     }
 
     private Build checkBuildAndReturn(long buildId, boolean isPR) {

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/repair/TestNPERepairSafe.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/repair/TestNPERepairSafe.java
@@ -94,6 +94,10 @@ public class TestNPERepairSafe {
         List<RepairPatch> allPatches = inspector.getJobStatus().getAllPatches();
         assertThat(allPatches.size(), is(6));
         assertThat(inspector.getJobStatus().getToolDiagnostic().get(npeRepair.getRepairToolName()), notNullValue());
+
+        for (RepairPatch repairPatch : allPatches) {
+            assertTrue(new File(repairPatch.getFilePath()).exists());
+        }
     }
 
     private Build checkBuildAndReturn(long buildId, boolean isPR) {

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/repair/TestNopolRepair.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/repair/TestNopolRepair.java
@@ -102,6 +102,10 @@ public class TestNopolRepair {
         List<RepairPatch> allPatches = inspector.getJobStatus().getAllPatches();
         assertThat(allPatches.size(), is(9));
         assertThat(inspector.getJobStatus().getToolDiagnostic().get(nopolRepair.getRepairToolName()), notNullValue());
+
+        for (RepairPatch repairPatch : allPatches) {
+            assertTrue(new File(repairPatch.getFilePath()).exists());
+        }
     }
 
     private Build checkBuildAndReturn(long buildId, boolean isPR) {


### PR DESCRIPTION
Closes #1194 

## Changelog:
- Fixes buggy file path in NPERepair's and AssertFixer's RepairPatches
- Add assertions in repair step tests