### PR TITLE
refactor: SequencerCollectorScanner uses GithubActions instead of TravisCI

### DIFF
--- a/src/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/GithubScanner.java
+++ b/src/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/GithubScanner.java
@@ -2,7 +2,6 @@ package fr.inria.spirals.repairnator.realtime;
 
 import fr.inria.spirals.repairnator.GithubInputBuild;
 import fr.inria.spirals.repairnator.config.RepairnatorConfig;
-import fr.inria.spirals.repairnator.config.SequencerConfig;
 import fr.inria.spirals.repairnator.realtime.githubapi.commits.GithubAPICommitAdapter;
 import fr.inria.spirals.repairnator.realtime.githubapi.commits.models.SelectedCommit;
 import fr.inria.spirals.repairnator.states.LauncherMode;
@@ -14,7 +13,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 public class GithubScanner {
     static long scanIntervalDelay = 60 * 60 * 1000; // 1 hour
@@ -30,7 +28,7 @@ public class GithubScanner {
         Set<String> repos = null;
         String reposPath = System.getenv("REPOS_PATH");
         if (reposPath != null)
-            repos = new HashSet<String>(FileUtils.readLines(new File(reposPath), "UTF-8"));
+            repos = new HashSet<>(FileUtils.readLines(new File(reposPath), "UTF-8"));
 
         FetchMode fetchMode = parseFetchMode();
 
@@ -80,7 +78,7 @@ public class GithubScanner {
     }
 
     public List<SelectedCommit> fetch(long startTime, long endTime) throws Exception {
-        return GithubAPICommitAdapter.getInstance().getSelectedCommits(startTime, endTime, fetchMode, repos);
+        return GithubAPICommitAdapter.getInstance().getSelectedCommits(startTime, endTime, fetchMode, null);
     }
 
     public void process(SelectedCommit commit) {

--- a/src/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/GithubScanner.java
+++ b/src/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/GithubScanner.java
@@ -78,7 +78,7 @@ public class GithubScanner {
     }
 
     public List<SelectedCommit> fetch(long startTime, long endTime) throws Exception {
-        return GithubAPICommitAdapter.getInstance().getSelectedCommits(startTime, endTime, fetchMode, null);
+        return GithubAPICommitAdapter.getInstance().getSelectedCommits(startTime, endTime, fetchMode, repos);
     }
 
     public void process(SelectedCommit commit) {
@@ -104,6 +104,8 @@ public class GithubScanner {
         switch (value) {
             case "all":
                 return FetchMode.ALL;
+            case "passing":
+                return FetchMode.PASSING;
             case "failed":
             default:
                 return FetchMode.FAILED;
@@ -111,6 +113,6 @@ public class GithubScanner {
     }
 
     public enum FetchMode {
-        FAILED, ALL;
+        FAILED, ALL, PASSING
     }
 }

--- a/src/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerLearnerScanner.java
+++ b/src/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerLearnerScanner.java
@@ -1,39 +1,32 @@
 package fr.inria.spirals.repairnator.realtime;
 
-import fr.inria.jtravis.entities.StateType;
-import fr.inria.jtravis.entities.v2.BuildV2;
-import fr.inria.jtravis.entities.v2.JobV2;
 import fr.inria.spirals.repairnator.config.RepairnatorConfig;
 import fr.inria.spirals.repairnator.config.SequencerConfig;
+import fr.inria.spirals.repairnator.realtime.githubapi.commits.models.SelectedCommit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Scanner based on FastScanner.java but re-purposed for scanning for Sequencer training data.
  */
 public class SequencerLearnerScanner implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(SequencerLearnerScanner.class);
-    private BuildHelperV2 buildHelper;
-    
+
     public static void main(String[] args) {
         new SequencerLearnerScanner().run();
-        
     }
     
-    public SequencerLearnerScanner() {
-        buildHelper = new BuildHelperV2(RepairnatorConfig.getInstance().getJTravis());
-    }
-
     @Override
     public void run() {
         LOGGER.debug("Start running inspect Jobs...");
-        JobHelperv2 jobHelperv2 = new JobHelperv2(RepairnatorConfig.getInstance().getJTravis());
+
+        GithubScanner scanner = new GithubScanner(GithubScanner.FetchMode.ALL); // replace for PASSING
         SequencerCollector collector;
         
         try {
@@ -43,42 +36,24 @@ public class SequencerLearnerScanner implements Runnable {
             throw new RuntimeException(e1);
         }
         
-        final int scanBackIterations = 10;
-        final int jumpSize = 250;
-        
-        Set<Integer> done = new HashSet<>();
-        
+        Set<String> done = new HashSet<>();
         while (true) {
             try {
-                Optional<List<JobV2>> latestJobListOpt = jobHelperv2.allFromV2();
-                List<JobV2> latestJobList = latestJobListOpt.get();
-                int latestJobId = latestJobList.get(0).getId();
-            	for (int it = 0; it < scanBackIterations; ++it) {
-            		
-            		List<JobV2> jobList = jobHelperv2.allSubSequentJobsFrom(latestJobId - (it*jumpSize));
-            		for (JobV2 job : jobList) {
-                    	if (!done.contains(job.getBuildId()) && "java".equals(job.getConfig().getLanguage()) && StateType.PASSED.equals(job.getState())) {
-                        	
-                    	    Optional<BuildV2> build = buildHelper.fromIdV2(job.getBuildId());
-                    	    
-                    	    if (!build.isPresent()) {
-                                continue;
-                            }
-                    	    
-                    	    String sha = build.get().getCommit().getSha();
-                    	    
-                    	    collector.handle(job.getRepositorySlug(), sha);   
-                        	done.add(job.getBuildId());
-                        }
+                List<SelectedCommit> latestJobList = scanner.fetch(); // default fetch?
+            		for (SelectedCommit job : latestJobList) {
+                    	    collector.handle(job.getRepoName(), job.getCommitId());
+                        	done.add(job.getRepoName() + job.getCommitId());
                     }
-            	}
-                
-
+                TimeUnit.MILLISECONDS.sleep(60 * 60 * 1000); // 1 hour
+            } catch (InterruptedException e){
+                System.err.println("Wait period interrupted.");
+                throw new RuntimeException(e);
             } catch (Exception e) {
                 System.err.println(e.toString());
                 System.err.println("failed to get commit");
                 //throw new RuntimeException(e);
             }
+
         } // end while loop
     }
 

--- a/src/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerLearnerScanner.java
+++ b/src/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/SequencerLearnerScanner.java
@@ -1,6 +1,5 @@
 package fr.inria.spirals.repairnator.realtime;
 
-import fr.inria.spirals.repairnator.config.RepairnatorConfig;
 import fr.inria.spirals.repairnator.config.SequencerConfig;
 import fr.inria.spirals.repairnator.realtime.githubapi.commits.models.SelectedCommit;
 import org.slf4j.Logger;
@@ -26,7 +25,7 @@ public class SequencerLearnerScanner implements Runnable {
     public void run() {
         LOGGER.debug("Start running inspect Jobs...");
 
-        GithubScanner scanner = new GithubScanner(GithubScanner.FetchMode.ALL); // replace for PASSING
+        GithubScanner scanner = new GithubScanner(GithubScanner.FetchMode.PASSING);
         SequencerCollector collector;
         
         try {

--- a/src/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/githubapi/commits/GithubAPICommitAdapter.java
+++ b/src/repairnator-realtime/src/main/java/fr/inria/spirals/repairnator/realtime/githubapi/commits/GithubAPICommitAdapter.java
@@ -45,6 +45,10 @@ public class GithubAPICommitAdapter {
                 case ALL:
                     res.add(new SelectedCommit(isGithubActionsFailed, commit.getSHA1(), repo.getFullName()));
                     break;
+                case PASSING:
+                    if(!isGithubActionsFailed)
+                        res.add(new SelectedCommit(isGithubActionsFailed, commit.getSHA1(), repo.getFullName()));
+                    break;
                 case FAILED:
                 default:
                     if(isGithubActionsFailed)

--- a/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestGithubScanner.java
+++ b/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestGithubScanner.java
@@ -48,6 +48,7 @@ public class TestGithubScanner {
                 scanner.fetch(new SimpleDateFormat("dd/MM/yyyy").parse("01/12/2020").getTime(),
                         new SimpleDateFormat("dd/MM/yyyy").parse("27/01/2021").getTime());
         assertTrue(commits.stream().anyMatch(x -> x.getCommitId().equals("290bdc01884f7c9bf2140a7c66d22ca72fe50fbb")));
+        assertTrue(commits.stream().anyMatch(x -> x.getCommitId().equals("e3456813fdcca1ed5075c0fb72b0bcbc9524e791")));
     }
 
     @Test
@@ -63,6 +64,21 @@ public class TestGithubScanner {
                         new SimpleDateFormat("dd/MM/yyyy").parse("27/01/2021").getTime());
         assertFalse(commits.stream().anyMatch(x -> x.getCommitId().equals("290bdc01884f7c9bf2140a7c66d22ca72fe50fbb")));
         assertTrue(commits.stream().anyMatch(x -> x.getCommitId().equals("e3456813fdcca1ed5075c0fb72b0bcbc9524e791")));
+    }
+
+    @Test
+    public void testFetchingPassing() throws Exception {
+
+        Set<String> repos = new HashSet<String>(FileUtils.readLines(new File(getClass()
+                .getResource("/GithubScannerTest_repos.txt").getFile()), "UTF-8"));
+        GithubScanner scanner = new GithubScanner(GithubScanner.FetchMode.PASSING, repos);
+        scanner.setup();
+
+        List<SelectedCommit> commits =
+                scanner.fetch(new SimpleDateFormat("dd/MM/yyyy").parse("01/12/2020").getTime(),
+                        new SimpleDateFormat("dd/MM/yyyy").parse("27/01/2021").getTime());
+        assertTrue(commits.stream().anyMatch(x -> x.getCommitId().equals("290bdc01884f7c9bf2140a7c66d22ca72fe50fbb")));
+        assertFalse(commits.stream().anyMatch(x -> x.getCommitId().equals("e3456813fdcca1ed5075c0fb72b0bcbc9524e791")));
     }
 
 }


### PR DESCRIPTION
* Changed SequencerCollectorScanner's source to GitHub actions.
* Modified @khaes-kth GitHub scanner to also provide an "only passing" filter.