### PR TITLE
refactor: Overfitting detection as an AbstractRepairStep component

### DIFF
--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
@@ -132,11 +132,6 @@ public class LauncherUtils {
         // --sequencerRepair
         jsap.registerParameter(LauncherUtils.defineArgSequencerRepairMode());
 
-        // --patchRanking
-        jsap.registerParameter(LauncherUtils.defineArgPatchRanking());
-        // --patchRankingMode
-        jsap.registerParameter(LauncherUtils.defineArgPatchRankingMode());
-
         // --patchClassification
         jsap.registerParameter(LauncherUtils.defineArgPatchClassification());
         // --patchClassificationMode
@@ -245,8 +240,6 @@ public class LauncherUtils {
         config.setNPEScope(LauncherUtils.getArgNPEScope(arguments));
         config.setNPERepairStrategy(LauncherUtils.getArgNPERepairStrategy(arguments));
 
-        config.setPatchRankingMode(LauncherUtils.getArgPatchRankingMode(arguments));
-        config.setPatchRanking(LauncherUtils.getArgPatchRanking(arguments));
         config.setPatchClassificationMode(LauncherUtils.getArgPatchClassificationMode(arguments));
         config.setPatchClassification(LauncherUtils.getArgPatchClassification(arguments));
         config.setPatchFiltering(LauncherUtils.getArgPatchFiltering(arguments));
@@ -1035,31 +1028,6 @@ public class LauncherUtils {
 
     public static RepairnatorConfig.PATCH_FILTERING_MODE getArgPatchFilteringMode(JSAPResult arguments) {
         return RepairnatorConfig.PATCH_FILTERING_MODE.valueOf(arguments.getString("patchFilteringMode"));
-    }
-
-    public static Switch defineArgPatchRanking() {
-        Switch sw = new Switch("patchRanking");
-        sw.setLongFlag("patchRanking");
-        sw.setDefault("false");
-        sw.setHelp("Rank repair patches using the defined mode.");
-        return sw;
-    }
-
-    public static boolean getArgPatchRanking(JSAPResult arguments) {
-        return arguments.getBoolean("patchRanking");
-    }
-
-    public static FlaggedOption defineArgPatchRankingMode() {
-        FlaggedOption opt = new FlaggedOption("patchRankingMode");
-        opt.setLongFlag("patchRankingMode");
-        opt.setStringParser(JSAP.STRING_PARSER);
-        opt.setDefault(RepairnatorConfig.PATCH_RANKING_MODE.NONE.name());
-        opt.setHelp("Possible string values NONE, OVERFITTING.");
-        return opt;
-    }
-
-    public static RepairnatorConfig.PATCH_RANKING_MODE getArgPatchRankingMode(JSAPResult arguments) {
-        return RepairnatorConfig.PATCH_RANKING_MODE.valueOf(arguments.getString("patchRankingMode"));
     }
 
     public static void checkPushUrlArg(JSAP jsap, JSAPResult arguments, LauncherType launcherType) {

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
@@ -132,8 +132,24 @@ public class LauncherUtils {
         // --sequencerRepair
         jsap.registerParameter(LauncherUtils.defineArgSequencerRepairMode());
 
+        // --patchRanking
+        jsap.registerParameter(LauncherUtils.defineArgPatchRanking());
         // --patchRankingMode
         jsap.registerParameter(LauncherUtils.defineArgPatchRankingMode());
+
+        // --patchClassification
+        jsap.registerParameter(LauncherUtils.defineArgPatchClassification());
+        // --patchClassificationMode
+        jsap.registerParameter(LauncherUtils.defineArgPatchClassificationMode());
+
+        // --patchFiltering
+        jsap.registerParameter(LauncherUtils.defineArgPatchFiltering());
+        // --patchFilteringMode
+        jsap.registerParameter(LauncherUtils.defineArgPatchFilteringMode());
+
+        // --odsPath
+        jsap.registerParameter(LauncherUtils.defineArgODSPath());
+
     }
 
     public static void initCommonConfig(RepairnatorConfig config, JSAPResult arguments) {
@@ -230,6 +246,13 @@ public class LauncherUtils {
         config.setNPERepairStrategy(LauncherUtils.getArgNPERepairStrategy(arguments));
 
         config.setPatchRankingMode(LauncherUtils.getArgPatchRankingMode(arguments));
+        config.setPatchRanking(LauncherUtils.getArgPatchRanking(arguments));
+        config.setPatchClassificationMode(LauncherUtils.getArgPatchClassificationMode(arguments));
+        config.setPatchClassification(LauncherUtils.getArgPatchClassification(arguments));
+        config.setPatchFiltering(LauncherUtils.getArgPatchFiltering(arguments));
+        config.setPatchFilteringMode(LauncherUtils.getArgPatchFilteringMode(arguments));
+
+        config.setODSPath(LauncherUtils.getArgODSPath(arguments).getAbsolutePath());
     }
 
     public static Switch defineArgHelp() {
@@ -947,6 +970,85 @@ public class LauncherUtils {
         return arguments.getString("npeRepairStrategy");
     }
 
+    public static FlaggedOption defineArgODSPath() {
+        FlaggedOption opt = new FlaggedOption("odsPath");
+        opt.setLongFlag("odsPath");
+        opt.setDefault("./repairnator-output/ODSPatches");
+        opt.setStringParser(JSAP.STRING_PARSER);
+        opt.setHelp("Path for ODS output");
+        return opt;
+    }
+
+    public static File getArgODSPath(JSAPResult arguments) {
+        File output = new File(arguments.getString("odsPath"));
+        if (!output.exists()) {
+            output.mkdirs();
+        }
+        return output;
+    }
+
+    public static Switch defineArgPatchClassification() {
+        Switch sw = new Switch("patchClassification");
+        sw.setLongFlag("patchClassification");
+        sw.setDefault("false");
+        sw.setHelp("Classify repair patches using the defined mode.");
+        return sw;
+    }
+
+    public static boolean getArgPatchClassification(JSAPResult arguments) {
+        return arguments.getBoolean("patchClassification");
+    }
+
+    public static FlaggedOption defineArgPatchClassificationMode() {
+        FlaggedOption opt = new FlaggedOption("patchClassificationMode");
+        opt.setLongFlag("patchClassificationMode");
+        opt.setStringParser(JSAP.STRING_PARSER);
+        opt.setDefault(RepairnatorConfig.PATCH_CLASSIFICATION_MODE.NONE.name());
+        opt.setHelp("Possible string values NONE, ODS.");
+        return opt;
+    }
+
+    public static RepairnatorConfig.PATCH_CLASSIFICATION_MODE getArgPatchClassificationMode(JSAPResult arguments) {
+        return RepairnatorConfig.PATCH_CLASSIFICATION_MODE.valueOf(arguments.getString("patchClassificationMode"));
+    }
+
+    public static Switch defineArgPatchFiltering() {
+        Switch sw = new Switch("patchFiltering");
+        sw.setLongFlag("patchFiltering");
+        sw.setDefault("false");
+        sw.setHelp("Filter repair patches using the defined mode.");
+        return sw;
+    }
+
+    public static boolean getArgPatchFiltering(JSAPResult arguments) {
+        return arguments.getBoolean("patchFiltering");
+    }
+
+    public static FlaggedOption defineArgPatchFilteringMode() {
+        FlaggedOption opt = new FlaggedOption("patchFilteringMode");
+        opt.setLongFlag("patchFilteringMode");
+        opt.setStringParser(JSAP.STRING_PARSER);
+        opt.setDefault(RepairnatorConfig.PATCH_FILTERING_MODE.NONE.name());
+        opt.setHelp("Possible string values NONE, ODS_CORRECT.");
+        return opt;
+    }
+
+    public static RepairnatorConfig.PATCH_FILTERING_MODE getArgPatchFilteringMode(JSAPResult arguments) {
+        return RepairnatorConfig.PATCH_FILTERING_MODE.valueOf(arguments.getString("patchFilteringMode"));
+    }
+
+    public static Switch defineArgPatchRanking() {
+        Switch sw = new Switch("patchRanking");
+        sw.setLongFlag("patchRanking");
+        sw.setDefault("false");
+        sw.setHelp("Rank repair patches using the defined mode.");
+        return sw;
+    }
+
+    public static boolean getArgPatchRanking(JSAPResult arguments) {
+        return arguments.getBoolean("patchRanking");
+    }
+
     public static FlaggedOption defineArgPatchRankingMode() {
         FlaggedOption opt = new FlaggedOption("patchRankingMode");
         opt.setLongFlag("patchRankingMode");
@@ -956,8 +1058,8 @@ public class LauncherUtils {
         return opt;
     }
 
-    public static String getArgPatchRankingMode(JSAPResult arguments) {
-        return arguments.getString("patchRankingMode");
+    public static RepairnatorConfig.PATCH_RANKING_MODE getArgPatchRankingMode(JSAPResult arguments) {
+        return RepairnatorConfig.PATCH_RANKING_MODE.valueOf(arguments.getString("patchRankingMode"));
     }
 
     public static void checkPushUrlArg(JSAP jsap, JSAPResult arguments, LauncherType launcherType) {
@@ -968,7 +1070,6 @@ public class LauncherUtils {
             }
         }
     }
-
 
     public static void printUsage(JSAP jsap, LauncherType launcherType) {
         String moduleName = "repairnator-" + launcherType.name().toLowerCase();

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
@@ -58,6 +58,11 @@ public class RepairnatorConfig {
         NONE,
         ODS
     }
+
+    public enum PATCH_FILTERING_MODE {
+        NONE,
+        ODS_CORRECT
+    }
    
     /** 
       * DEFAULT - the project files is scanned by Sorald as a single unit. If the repair fails then it fails completely and no fixes are produced if there could have been any
@@ -116,6 +121,7 @@ public class RepairnatorConfig {
     private String localMavenRepository;
     private String jTravisEndpoint;
     private String travisToken;
+    private String ODSPath;
 
     private String gitRepositoryUrl;
     private String gitRepositoryBranch;
@@ -135,9 +141,11 @@ public class RepairnatorConfig {
     private String npeRepairStrategy;
 
     private PATCH_RANKING_MODE patchRankingMode;
-    
     private PATCH_CLASSIFICATION_MODE patchClassificationMode;
-
+    private PATCH_FILTERING_MODE patchFilteringMode;
+    private boolean patchClassification;
+    private boolean patchFiltering;
+    private boolean patchRanking;
 
     // Dockerpool
     private String dockerImageName;
@@ -808,35 +816,6 @@ public class RepairnatorConfig {
         this.npeRepairStrategy = npeRepairStrategy;
     }
 
-    public PATCH_RANKING_MODE getPatchRankingMode() {
-        return patchRankingMode;
-    }
-    
-
-    public void setPatchRankingMode(String patchRankingMode) {
-        for (PATCH_RANKING_MODE mode: PATCH_RANKING_MODE.values()) {
-            if (patchRankingMode.equals(mode.name())) {
-                this.patchRankingMode = PATCH_RANKING_MODE.valueOf(patchRankingMode);
-                return;
-            }
-        }
-        throw new RuntimeException("unknown patch ranking mode: " + patchRankingMode);
-    }
-
-    public PATCH_CLASSIFICATION_MODE getPatchClassificationMode() {
-        return patchClassificationMode;
-    }
-
-    public void setPatchClassificationMode(String patchClassificationMode) {
-        for (PATCH_CLASSIFICATION_MODE mode: PATCH_CLASSIFICATION_MODE.values()) {
-            if (patchClassificationMode.equals(mode.name())) {
-                this.patchClassificationMode = PATCH_CLASSIFICATION_MODE.valueOf(patchClassificationMode);
-                return;
-            }
-        }
-        throw new RuntimeException("unknown patch classification mode: " + patchClassificationMode);
-    }
-
     @Override
     public String toString() {
         String ghToken = this.getGithubToken();
@@ -1005,5 +984,61 @@ public class RepairnatorConfig {
 
     public void setTravisToken(String travisToken) {
         this.travisToken = travisToken;
+    }
+
+    public String getODSPath() {
+        return ODSPath;
+    }
+
+    public void setODSPath(String ODSPath) {
+        this.ODSPath = ODSPath;
+    }
+
+    public PATCH_RANKING_MODE getPatchRankingMode() {
+        return patchRankingMode;
+    }
+
+    public void setPatchRankingMode(PATCH_RANKING_MODE patchRankingMode) {
+        this.patchRankingMode = patchRankingMode;
+    }
+
+    public boolean isPatchRanking() {
+        return patchRanking;
+    }
+
+    public void setPatchRanking(boolean patchRanking) {
+        this.patchRanking = patchRanking;
+    }
+
+    public PATCH_CLASSIFICATION_MODE getPatchClassificationMode() {
+        return patchClassificationMode;
+    }
+
+    public void setPatchClassificationMode(PATCH_CLASSIFICATION_MODE patchClassificationMode) {
+        this.patchClassificationMode = patchClassificationMode;
+    }
+
+    public boolean isPatchClassification() {
+        return patchClassification;
+    }
+
+    public void setPatchClassification(boolean patchClassification) {
+        this.patchClassification = patchClassification;
+    }
+
+    public PATCH_FILTERING_MODE getPatchFilteringMode() {
+        return patchFilteringMode;
+    }
+
+    public void setPatchFilteringMode(PATCH_FILTERING_MODE patchFilteringMode) {
+        this.patchFilteringMode = patchFilteringMode;
+    }
+
+    public boolean isPatchFiltering() {
+        return patchFiltering;
+    }
+
+    public void setPatchFiltering(boolean patchFiltering) {
+        this.patchFiltering = patchFiltering;
     }
 }

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
@@ -49,11 +49,6 @@ public class RepairnatorConfig {
         }
     }
 
-    public enum PATCH_RANKING_MODE {
-        NONE,
-        OVERFITTING
-    }
-
     public enum PATCH_CLASSIFICATION_MODE {
         NONE,
         ODS
@@ -140,12 +135,10 @@ public class RepairnatorConfig {
     private String npeScope;
     private String npeRepairStrategy;
 
-    private PATCH_RANKING_MODE patchRankingMode;
     private PATCH_CLASSIFICATION_MODE patchClassificationMode;
     private PATCH_FILTERING_MODE patchFilteringMode;
     private boolean patchClassification;
     private boolean patchFiltering;
-    private boolean patchRanking;
 
     // Dockerpool
     private String dockerImageName;
@@ -886,7 +879,6 @@ public class RepairnatorConfig {
                 ", mavenHome=" + mavenHome +
                 ", localMavenRepository=" + localMavenRepository +
                 ", noTravisRepair=" + noTravisRepair +
-                ", rankPatches=" + patchRankingMode +
                 ", jTravisEndpoint=" + jTravisEndpoint +
                 ", travisToken=" + travisToken +
                 '}';
@@ -992,22 +984,6 @@ public class RepairnatorConfig {
 
     public void setODSPath(String ODSPath) {
         this.ODSPath = ODSPath;
-    }
-
-    public PATCH_RANKING_MODE getPatchRankingMode() {
-        return patchRankingMode;
-    }
-
-    public void setPatchRankingMode(PATCH_RANKING_MODE patchRankingMode) {
-        this.patchRankingMode = patchRankingMode;
-    }
-
-    public boolean isPatchRanking() {
-        return patchRanking;
-    }
-
-    public void setPatchRanking(boolean patchRanking) {
-        this.patchRanking = patchRanking;
     }
 
     public PATCH_CLASSIFICATION_MODE getPatchClassificationMode() {

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/SequencerConfig.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/SequencerConfig.java
@@ -19,7 +19,6 @@ public final class SequencerConfig {
     public final String collectorPath;
     public final int contextSize;
     public final RAW_URL_SOURCE rawURLSource;
-    public final String ODSPath;
 
     private static SequencerConfig instance;
 
@@ -31,7 +30,6 @@ public final class SequencerConfig {
         this.collectorPath = getEnvOrDefault("SEQUENCER_COLLECTOR_PATH",
                 System.getProperty("user.home") + "/continuous-learning-data");
         this.contextSize = Integer.parseInt(getEnvOrDefault("SEQUENCER_CONTEXT_SIZE", "3"));
-        this.ODSPath = (getEnvOrDefault("SEQUENCER_ODS_PATH", RepairnatorConfig.getInstance().getOutputPath() + "/ODSPatches"));
         this.rawURLSource = parseRawURLSource();
 
     }

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/dockerpool/RunnablePipelineContainer.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/dockerpool/RunnablePipelineContainer.java
@@ -118,7 +118,6 @@ public class RunnablePipelineContainer implements Runnable {
             this.envValues.add("SEQUENCER_THREADS=" + sequencerConfig.threads);
             this.envValues.add("SEQUENCER_BEAM_SIZE=" + sequencerConfig.beamSize);
             this.envValues.add("SEQUENCER_TIMEOUT=" + sequencerConfig.timeout);
-            this.envValues.add("SEQUENCER_ODS_PATH=" + sequencerConfig.ODSPath);
         }
     }
 
@@ -167,7 +166,7 @@ public class RunnablePipelineContainer implements Runnable {
                     .appendBinds(HostConfig.Bind
                             .builder()
                             .from(ODSVolume)
-                            .to(SequencerConfig.getInstance().ODSPath)
+                            .to(RepairnatorConfig.getInstance().getODSPath())
                             .build())
                     .build();
 

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/JobStatus.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/JobStatus.java
@@ -1,18 +1,15 @@
 package fr.inria.spirals.repairnator.process.inspectors;
 
 import com.google.gson.JsonElement;
-import fr.inria.spirals.repairnator.config.RepairnatorConfig;
-import fr.inria.spirals.repairnator.config.RepairnatorConfig.PATCH_RANKING_MODE;
 import fr.inria.spirals.repairnator.process.inspectors.properties.Properties;
 import fr.inria.spirals.repairnator.process.inspectors.properties.features.Features;
 import fr.inria.spirals.repairnator.process.inspectors.properties.tests.FailureDetail;
 import fr.inria.spirals.repairnator.process.step.StepStatus;
 import fr.inria.spirals.repairnator.process.testinformation.FailureLocation;
 import fr.inria.spirals.repairnator.states.PushState;
+import org.apache.maven.model.Plugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.apache.maven.model.Plugin;
 
 import java.io.File;
 import java.net.URL;
@@ -276,23 +273,6 @@ public class JobStatus {
         return allPatches;
     }
 
-    public List<RepairPatch> getRankedPatches() {
-        return getRankedPatches(Features.P4J);
-    }
-
-    protected List<RepairPatch> getRankedPatches(Features features) {
-        List<RepairPatch> allPatches = getAllPatches();
-        PATCH_RANKING_MODE patchRankingMode = RepairnatorConfig.getInstance().getPatchRankingMode();
-
-        switch (patchRankingMode){
-            case OVERFITTING:
-                allPatches.sort(RepairPatch.rankByOverfittingWithFeatures(features));
-                break;
-        }
-        return allPatches;
-    }
-    
-    
     protected List<RepairPatch> getCorrectnessLabeledPatches(Features features, String buildId) {
         List<RepairPatch> allPatches = getAllPatches();
         return RepairPatch.classifyByODSWithFeatures(allPatches, buildId);

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/RepairPatch.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/RepairPatch.java
@@ -7,6 +7,7 @@ import com.github.difflib.patch.PatchFailedException;
 import fr.inria.coming.codefeatures.RepairnatorFeatures;
 import fr.inria.coming.codefeatures.RepairnatorFeatures.ODSLabel;
 import fr.inria.coming.main.ComingProperties;
+import fr.inria.spirals.repairnator.config.RepairnatorConfig;
 import fr.inria.spirals.repairnator.config.SequencerConfig;
 import fr.inria.spirals.repairnator.process.inspectors.properties.features.Features;
 import fr.inria.spirals.repairnator.process.inspectors.properties.features.Overfitting;
@@ -23,7 +24,7 @@ import org.apache.log4j.Logger;
 
 public class RepairPatch {
 
-	static final String ODSPath = SequencerConfig.getInstance().ODSPath;
+	static final String ODSPath = RepairnatorConfig.getInstance().getODSPath();
 	protected static Logger log = Logger.getLogger(Thread.currentThread().getName());
 
 	/**
@@ -218,7 +219,7 @@ public class RepairPatch {
 	
 			// create a directory to store the patch: "patches/"+buildId+patchId
 			String buggyClassName = buggyFile.getName().replace(".java", "");
-			String odsFilesPath = SequencerConfig.getInstance().ODSPath;
+			String odsFilesPath = this.ODSPath;
 	
 			String patchPath = odsFilesPath + "/" + buildId + "-" + patchId;
 			Path path = Paths.get(patchPath + '/' + buggyClassName);

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/RepairPatch.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/RepairPatch.java
@@ -24,7 +24,6 @@ import org.apache.log4j.Logger;
 
 public class RepairPatch {
 
-	static final String ODSPath = RepairnatorConfig.getInstance().getODSPath();
 	protected static Logger log = Logger.getLogger(Thread.currentThread().getName());
 
 	/**
@@ -146,11 +145,6 @@ public class RepairPatch {
 		return Objects.hash(toolname, filePath, diff);
 	}
 
-	// ranking algorithms
-	public static Comparator<RepairPatch> rankByOverfittingWithFeatures(Features features) {
-		return (x, y) -> overfittingSort(x, y, features);
-	}
-
 	private static int overfittingSort(RepairPatch patch1, RepairPatch patch2, Features features) { // ascending
 		double score1 = patch1.getOverfittingScore(features);
 		double score2 = patch2.getOverfittingScore(features);
@@ -165,9 +159,11 @@ public class RepairPatch {
 
 	// ODS classification
 	public static List<RepairPatch> classifyByODSWithFeatures(List<RepairPatch> allPatches, String buildId) {
+	    String ODSPath = RepairnatorConfig.getInstance().getODSPath();
 
 		File f = new File(ODSPath);
-		f.mkdir();
+		f.mkdirs();
+
 
 		int len = allPatches.size();
 
@@ -193,8 +189,9 @@ public class RepairPatch {
 	}
 
 	private ODSLabel computeODSLabel(int patchId, String buildId) {
-		
-		ODSLabel label = ODSLabel.UNKNOWN;
+        String ODSPath = RepairnatorConfig.getInstance().getODSPath();
+
+        ODSLabel label = ODSLabel.UNKNOWN;
 
 		try {		
 			File buggyFile = new File(filePath);
@@ -219,7 +216,7 @@ public class RepairPatch {
 	
 			// create a directory to store the patch: "patches/"+buildId+patchId
 			String buggyClassName = buggyFile.getName().replace(".java", "");
-			String odsFilesPath = this.ODSPath;
+			String odsFilesPath = ODSPath;
 	
 			String patchPath = odsFilesPath + "/" + buildId + "-" + patchId;
 			Path path = Paths.get(patchPath + '/' + buggyClassName);

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AbstractNPERepairStep.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AbstractNPERepairStep.java
@@ -179,6 +179,10 @@ public abstract class AbstractNPERepairStep extends AbstractRepairStep {
                     }
                 }
 
+                repairPatches = this.performPatchAnalysis(repairPatches);
+                if (repairPatches.isEmpty()) {
+                    return StepStatus.buildPatchNotFound(this);
+                }
                 this.recordPatches(repairPatches, MAX_PATCH_PER_TOOL);
             }
 

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AbstractRepairStep.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AbstractRepairStep.java
@@ -1,6 +1,8 @@
 package fr.inria.spirals.repairnator.process.step.repair;
 
 import com.google.gson.JsonElement;
+import fr.inria.coming.codefeatures.RepairnatorFeatures;
+import fr.inria.coming.core.engine.git.GITRepositoryInspector;
 import fr.inria.spirals.repairnator.config.RepairnatorConfig;
 import fr.inria.spirals.repairnator.notifier.PatchNotifier;
 import fr.inria.spirals.repairnator.process.git.GitHelper;
@@ -29,6 +31,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public abstract class AbstractRepairStep extends AbstractStep {
 
@@ -103,6 +106,80 @@ public abstract class AbstractRepairStep extends AbstractStep {
 
     protected void setPRTitle(String prTitle) {
         this.prTitle = prTitle;
+    }
+
+    private List<RepairPatch> classifyPatches(List<RepairPatch> patches) {
+        RepairnatorConfig.PATCH_CLASSIFICATION_MODE mode = RepairnatorConfig.getInstance().getPatchClassificationMode();
+        this.getLogger().info("Classifying patches with mode " + mode.name());
+
+        if (patches.isEmpty()) {
+            return patches;
+        } else if (mode.equals(RepairnatorConfig.PATCH_CLASSIFICATION_MODE.ODS)) {
+            if (this.getInspector() instanceof GitRepositoryProjectInspector) {
+                GitRepositoryProjectInspector gitInspector = (GitRepositoryProjectInspector) this.getInspector();
+                patches = RepairPatch.classifyByODSWithFeatures(
+                        patches,
+                        (gitInspector.getRepoSlug() + "-" + gitInspector.getGitRepositoryIdCommit()).replace("/", "-")
+                );
+            } else {
+                patches = RepairPatch.classifyByODSWithFeatures(patches, this.getInspector().getBuildToBeInspected().getRunId());
+            }
+        } else if (mode.equals(RepairnatorConfig.PATCH_CLASSIFICATION_MODE.NONE)) {
+            this.getLogger().info("Classification mode is NONE so no patch will be classified");
+        }
+
+        patches.forEach(patch -> this.getLogger().debug("patch: " + patch.getFilePath() + " " + patch.getODSLabel()));
+        return patches;
+    }
+
+    private List<RepairPatch> rankPatches(List<RepairPatch> patches) {
+        RepairnatorConfig.PATCH_RANKING_MODE mode = RepairnatorConfig.getInstance().getPatchRankingMode();
+        this.getLogger().info("Ranking patches with mode " + mode.name());
+
+        if (patches.isEmpty()) {
+            return patches;
+        } else if (mode.equals(RepairnatorConfig.PATCH_RANKING_MODE.OVERFITTING)) {
+            this.getLogger().info("Ranking by overfitting score is not supported yet");
+        } else if (mode.equals(RepairnatorConfig.PATCH_RANKING_MODE.NONE)) {
+            this.getLogger().info("Ranking mode is NONE so no patch will be ranked");
+        }
+
+        return patches;
+    }
+
+    private List<RepairPatch> filterPatches(List<RepairPatch> patches) {
+        RepairnatorConfig.PATCH_FILTERING_MODE mode = RepairnatorConfig.getInstance().getPatchFilteringMode();
+        this.getLogger().info("Filtering " + patches.size() + " patches with mode " + mode.name());
+
+        if (patches.isEmpty()) {
+            return patches;
+        } else if (mode.equals(RepairnatorConfig.PATCH_FILTERING_MODE.ODS_CORRECT)) {
+            patches = patches.stream()
+                    .filter(patch -> patch.getODSLabel().equals(RepairnatorFeatures.ODSLabel.CORRECT))
+                    .collect(Collectors.toList());
+        } else if (mode.equals(RepairnatorConfig.PATCH_FILTERING_MODE.NONE)) {
+            this.getLogger().info("Filtering mode is NONE so no patch will be filtered");
+        }
+
+        this.getLogger().info("Number of patches after filtering: " + patches.size());
+        return patches;
+    }
+
+    protected List<RepairPatch> performPatchAnalysis(List<RepairPatch> patchList) {
+        if (patchList.isEmpty()) {
+            return patchList;
+        }
+        if (RepairnatorConfig.getInstance().isPatchClassification()) {
+            patchList = this.classifyPatches(patchList);
+        }
+        if (RepairnatorConfig.getInstance().isPatchRanking()) {
+            patchList = this.rankPatches(patchList);
+        }
+        if (RepairnatorConfig.getInstance().isPatchFiltering()) {
+            patchList = this.filterPatches(patchList);
+        }
+
+        return patchList;
     }
 
     protected void recordPatches(List<RepairPatch> patchList,int patchNbsLimit) {

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AssertFixerRepair.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/AssertFixerRepair.java
@@ -155,6 +155,10 @@ public class AssertFixerRepair extends AbstractRepairStep {
             }
         }
 
+        listPatches = this.performPatchAnalysis(listPatches);
+        if (listPatches.isEmpty()) {
+            return StepStatus.buildPatchNotFound(this);
+        }
         this.recordPatches(listPatches,MAX_PATCH_PER_TOOL);
         this.recordToolDiagnostic(toolDiagnostic);
 

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/Sorald.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/Sorald.java
@@ -37,7 +37,7 @@ import sorald.Main;
 public class Sorald extends AbstractRepairStep {
     public static final String TOOL_NAME = "Sorald";
     public static final String RULE_LINK_TEMPLATE = "https://rules.sonarsource.com/java/RSPEC-";
-    private final List<RepairPatch> allPatches = new ArrayList<RepairPatch>();
+    private List<RepairPatch> allPatches = new ArrayList<RepairPatch>();
     private Git forkedGit;
     private String forkedRepo;
 
@@ -110,7 +110,11 @@ public class Sorald extends AbstractRepairStep {
             return StepStatus.buildPatchNotFound(this);
         }
 
-        this.getInspector().getJobStatus().addPatches(this.getRepairToolName(), allPatches);   
+        allPatches = this.performPatchAnalysis(allPatches);
+        if (allPatches.isEmpty()) {
+            return StepStatus.buildPatchNotFound(this);
+        }
+        this.recordPatches(allPatches, MAX_PATCH_PER_TOOL);
         if (this.getConfig().isCreatePR()) {
             this.setPrText(prTextBuilder.toString());
             try {
@@ -123,7 +127,6 @@ public class Sorald extends AbstractRepairStep {
             }
         } 
         System.out.println("All patches : " + allPatches.size());
-        this.notify(allPatches);
         return StepStatus.buildSuccess(this);
     }
 

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/astor/AstorRepair.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/astor/AstorRepair.java
@@ -178,6 +178,7 @@ public abstract class AstorRepair extends AbstractRepairStep {
             }
 
 
+            astorPatches = this.performPatchAnalysis(astorPatches);
             if (astorPatches.isEmpty()) {
                 return StepStatus.buildPatchNotFound(this);
             } else {

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/nopol/AbstractNopolRepair.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/nopol/AbstractNopolRepair.java
@@ -258,6 +258,7 @@ public abstract class AbstractNopolRepair extends AbstractRepairStep {
             }
         }
 
+        repairPatches = this.performPatchAnalysis(repairPatches);
         this.recordPatches(repairPatches,MAX_PATCH_PER_TOOL);
         this.recordToolDiagnostic(toolDiag);
 

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineArgs.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineArgs.java
@@ -179,10 +179,29 @@ public class TestPipelineArgs {
         assertEquals(defaultNPERepairStrategy, LauncherUtils.getArgNPERepairStrategy(arguments));
         assertEquals(defaultNPERepairStrategy, config.getNPERepairStrategy());
 
-        // default patch ranking mode
+        // default patch ranking parameters
         RepairnatorConfig.PATCH_RANKING_MODE defaultPatchRankingMode = RepairnatorConfig.PATCH_RANKING_MODE.NONE;
-        assertEquals(defaultPatchRankingMode.name(), LauncherUtils.getArgPatchRankingMode(arguments));
+        assertEquals(defaultPatchRankingMode, LauncherUtils.getArgPatchRankingMode(arguments));
         assertEquals(defaultPatchRankingMode, config.getPatchRankingMode());
+        boolean defaultPatchRanking = false;
+        assertEquals(defaultPatchRanking, LauncherUtils.getArgPatchRanking(arguments));
+        assertEquals(defaultPatchRanking, config.isPatchRanking());
+
+        // default patch classification parameters
+        RepairnatorConfig.PATCH_CLASSIFICATION_MODE defaultPatchClassificationMode = RepairnatorConfig.PATCH_CLASSIFICATION_MODE.NONE;
+        assertEquals(defaultPatchClassificationMode, LauncherUtils.getArgPatchClassificationMode(arguments));
+        assertEquals(defaultPatchClassificationMode, config.getPatchClassificationMode());
+        boolean defaultPatchClassification = false;
+        assertEquals(defaultPatchClassification, LauncherUtils.getArgPatchClassification(arguments));
+        assertEquals(defaultPatchClassification, config.isPatchClassification());
+
+        // default patch filtering parameters
+        RepairnatorConfig.PATCH_FILTERING_MODE defaultPatchFilteringMode = RepairnatorConfig.PATCH_FILTERING_MODE.NONE;
+        assertEquals(defaultPatchFilteringMode, LauncherUtils.getArgPatchFilteringMode(arguments));
+        assertEquals(defaultPatchFilteringMode, config.getPatchFilteringMode());
+        boolean defaultPatchFiltering = false;
+        assertEquals(defaultPatchFiltering, LauncherUtils.getArgPatchFiltering(arguments));
+        assertEquals(defaultPatchFiltering, config.isPatchFiltering());
 
         // the default repair tool
         assertEquals(1, ((FlaggedOption) launcher.defineArgs().getByLongFlag("repairTools")).getDefault().length);

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineArgs.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineArgs.java
@@ -179,14 +179,6 @@ public class TestPipelineArgs {
         assertEquals(defaultNPERepairStrategy, LauncherUtils.getArgNPERepairStrategy(arguments));
         assertEquals(defaultNPERepairStrategy, config.getNPERepairStrategy());
 
-        // default patch ranking parameters
-        RepairnatorConfig.PATCH_RANKING_MODE defaultPatchRankingMode = RepairnatorConfig.PATCH_RANKING_MODE.NONE;
-        assertEquals(defaultPatchRankingMode, LauncherUtils.getArgPatchRankingMode(arguments));
-        assertEquals(defaultPatchRankingMode, config.getPatchRankingMode());
-        boolean defaultPatchRanking = false;
-        assertEquals(defaultPatchRanking, LauncherUtils.getArgPatchRanking(arguments));
-        assertEquals(defaultPatchRanking, config.isPatchRanking());
-
         // default patch classification parameters
         RepairnatorConfig.PATCH_CLASSIFICATION_MODE defaultPatchClassificationMode = RepairnatorConfig.PATCH_CLASSIFICATION_MODE.NONE;
         assertEquals(defaultPatchClassificationMode, LauncherUtils.getArgPatchClassificationMode(arguments));

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/TestGlobalPatchAnalysis.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/TestGlobalPatchAnalysis.java
@@ -1,25 +1,20 @@
 package fr.inria.spirals.repairnator.process.inspectors;
 
-import fr.inria.coming.changeminer.entity.FinalResult;
-import fr.inria.coming.codefeatures.RepairnatorFeatures;
-import fr.inria.coming.main.ComingMain;
-import fr.inria.coming.utils.CommandSummary;
+import fr.inria.coming.codefeatures.RepairnatorFeatures.ODSLabel;
 import fr.inria.jtravis.entities.Build;
 import fr.inria.spirals.repairnator.BuildToBeInspected;
-import fr.inria.spirals.repairnator.process.inspectors.properties.features.Features;
-import fr.inria.spirals.repairnator.process.step.repair.NPERepair;
-import fr.inria.spirals.repairnator.process.step.repair.nopol.NopolSingleTestRepair;
-import fr.inria.spirals.repairnator.process.step.repair.sequencer.SequencerRepair;
 import fr.inria.spirals.repairnator.config.RepairnatorConfig;
 import fr.inria.spirals.repairnator.process.files.FileHelper;
-import fr.inria.spirals.repairnator.process.step.StepStatus;
 import fr.inria.spirals.repairnator.process.step.CloneRepository;
+import fr.inria.spirals.repairnator.process.step.StepStatus;
 import fr.inria.spirals.repairnator.process.step.TestProject;
 import fr.inria.spirals.repairnator.process.step.checkoutrepository.CheckoutBuggyBuild;
 import fr.inria.spirals.repairnator.process.step.gatherinfo.BuildShouldFail;
 import fr.inria.spirals.repairnator.process.step.gatherinfo.GatherTestInformation;
 import fr.inria.spirals.repairnator.process.step.paths.ComputeClasspath;
 import fr.inria.spirals.repairnator.process.step.paths.ComputeSourceDir;
+import fr.inria.spirals.repairnator.process.step.repair.NPERepair;
+import fr.inria.spirals.repairnator.process.step.repair.nopol.NopolSingleTestRepair;
 import fr.inria.spirals.repairnator.process.utils4tests.Utils4Tests;
 import fr.inria.spirals.repairnator.serializer.AbstractDataSerializer;
 import fr.inria.spirals.repairnator.states.ScannedBuildStatus;
@@ -29,14 +24,17 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import fr.inria.coming.codefeatures.RepairnatorFeatures.ODSLabel;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -117,50 +115,6 @@ public class TestGlobalPatchAnalysis {
 		assertThat(inspector.getJobStatus().getToolDiagnostic().get(nopolRepair.getRepairToolName()), notNullValue());
 	}
 
-	@Test
-	@Ignore
-	public void testRankingPatches() throws IOException {
-		long buildId = 564711868; // surli/failingProject build 564711868
-		Build build = this.checkBuildAndReturn(buildId, false);
-
-		tmpDir = Files.createTempDirectory("test_ranking").toFile();
-		BuildToBeInspected toBeInspected = new BuildToBeInspected(build, null, ScannedBuildStatus.ONLY_FAIL, "");
-		ProjectInspector inspector = new ProjectInspector(toBeInspected, tmpDir.getAbsolutePath(), null, null);
-
-		CloneRepository cloneStep = new CloneRepository(inspector);
-		NopolSingleTestRepair nopolRepair = new NopolSingleTestRepair();
-		nopolRepair.setProjectInspector(inspector);
-		NPERepair npeRepair = new NPERepair();
-		npeRepair.setProjectInspector(inspector);
-
-		RepairnatorConfig.getInstance().setRepairTools(
-				new HashSet<>(Arrays.asList(nopolRepair.getRepairToolName(), npeRepair.getRepairToolName())));
-		RepairnatorConfig.getInstance().setPatchRankingMode(RepairnatorConfig.PATCH_RANKING_MODE.OVERFITTING);
-
-		cloneStep.addNextStep(new CheckoutBuggyBuild(inspector, true)).addNextStep(new TestProject(inspector))
-				.addNextStep(new GatherTestInformation(inspector, true, new BuildShouldFail(), false))
-				.addNextStep(new ComputeClasspath(inspector, true))
-				.addNextStep(new ComputeSourceDir(inspector, true, false)).addNextStep(nopolRepair)
-				.addNextStep(npeRepair);
-		cloneStep.execute();
-
-		List<RepairPatch> rankedPatchesP4J = inspector.getJobStatus().getRankedPatches(Features.P4J);
-		List<RepairPatch> rankedPatchesS4R = inspector.getJobStatus().getRankedPatches(Features.S4R);
-
-		// test ranking by P4J overfitting-scores
-		assertThat(rankedPatchesP4J.get(0).getToolname(), is("NopolSingleTest"));
-		assertEquals(rankedPatchesP4J.get(0).getOverfittingScore(Features.P4J), -2590, 1);
-		assertThat(rankedPatchesP4J.get(4).getToolname(), is("NopolSingleTest"));
-		assertEquals(rankedPatchesP4J.get(4).getOverfittingScore(Features.P4J), -410, 1);
-
-		// test ranking by S4R overfitting-scores
-		assertThat(rankedPatchesS4R.get(0).getToolname(), is("NopolSingleTest"));
-		assertEquals(rankedPatchesS4R.get(0).getOverfittingScore(Features.S4R), -0.06, 0.001);
-		assertThat(rankedPatchesS4R.get(1).getToolname(), is("NopolSingleTest"));
-		assertEquals(rankedPatchesS4R.get(1).getOverfittingScore(Features.S4R), -0.05, 0.001);
-	}
-
-	
 	@Test
 	public void testODSPatchClassification() throws IOException {
 		RepairnatorConfig.getInstance().setPatchClassification(true);


### PR DESCRIPTION
Closes #1135

> Why not a separate pipeline step?

Currently repair steps call `recordPatches` when they finish their work, which calls the notifiers. If, after that, we have logic that can filter/rank/etc the patches, it messes up that logic.

> What is there to finish?

Are the patch ranking methods for ODS working (tests are ignored). If so, wouldn't it make more sense to have different modes for the different features? Instead of `OVERFITTING` we would have `ODS_P4J` and `ODS_S4R` for example. @monperrus wdyt?

Also, should ranking be done inside each repair step or overall? The later makes more sense to me, but would require a separate step for it and would mess up the observer pattern mentioned above.

## ChangeLog
- Add missing parameters to control patch ranking, filtering and classification to `LauncherUtils` and `RepairnatorConfig`. Update test accordingly.
- Move ranking (to finish), filtering and classification logic to a method in `AbstractRepairStep`. Update test accordingly. Ranking and filtering tests to be activated/written.