### PR TITLE
refactor: move almost all remaining tests to internal org and reactivate tests

### DIFF
--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/ProjectInspector.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/ProjectInspector.java
@@ -110,11 +110,11 @@ public class ProjectInspector {
 
     public ProjectInspector(BuildToBeInspected buildToBeInspected, String workspace, List<AbstractNotifier> notifiers) {
         this.buildToBeInspected = buildToBeInspected;
-        this.workspace = workspace;
+        this.workspace = new String(workspace);
         this.gitSlug = getRepoSlug();
         this.repoLocalPath = workspace + File.separator + getRepoSlug();
         long buildId = buildToBeInspected != null ? buildToBeInspected.getBuggyBuild().getId() : 0;
-        this.repoToPushLocalPath = repoLocalPath+"_topush_" + buildId;
+        this.repoToPushLocalPath = new String(repoLocalPath + "_topush_" + buildId);
         this.m2LocalPath = new File(this.repoLocalPath + File.separator + ".m2").getAbsolutePath();
         this.serializers = new ArrayList<AbstractDataSerializer>();
         this.gitHelper = new GitHelper();

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/ProjectInspector.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/ProjectInspector.java
@@ -110,11 +110,11 @@ public class ProjectInspector {
 
     public ProjectInspector(BuildToBeInspected buildToBeInspected, String workspace, List<AbstractNotifier> notifiers) {
         this.buildToBeInspected = buildToBeInspected;
-        this.workspace = new String(workspace);
+        this.workspace = workspace;
         this.gitSlug = getRepoSlug();
         this.repoLocalPath = workspace + File.separator + getRepoSlug();
         long buildId = buildToBeInspected != null ? buildToBeInspected.getBuggyBuild().getId() : 0;
-        this.repoToPushLocalPath = new String(repoLocalPath + "_topush_" + buildId);
+        this.repoToPushLocalPath = repoLocalPath + "_topush_" + buildId;
         this.m2LocalPath = new File(this.repoLocalPath + File.separator + ".m2").getAbsolutePath();
         this.serializers = new ArrayList<AbstractDataSerializer>();
         this.gitHelper = new GitHelper();

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineSequencerRepair.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineSequencerRepair.java
@@ -29,13 +29,11 @@ public class TestPipelineSequencerRepair {
 
     @Test
     public void TestPipelineSequencerRepairTool() throws Exception {
-        // 220926535 -> repairnator/failingProject -> test failure
+        // ec915681fbd6a8b2c30580b2618e62636204abe4 -> repairnator/failingProject -> syntax
         Launcher launcher = new Launcher(new String[]{
-                "--jtravisendpoint", "https://api.travis-ci.com",
-                "--build", "220926535",
                 "--sequencerRepair",
                 "--gitrepo",
-                "--gitrepourl", "https://github.com/javierron/failingProject",
+                "--gitrepourl", "https://github.com/repairnator/failingProject",
                 "--gitrepoidcommit", "ec915681fbd6a8b2c30580b2618e62636204abe4",
                 "--launcherMode", "SEQUENCER_REPAIR",
                 "--workspace", workspaceFolder.getRoot().getAbsolutePath(),
@@ -58,11 +56,11 @@ public class TestPipelineSequencerRepair {
 
     @Test
     public void TestPipelineBuildPassBranch() throws Exception{
-        // e182ccb9ef41b5adab602ed12bfc71b744ff0241 -> javierron/faining project -> test failure
+        // e182ccb9ef41b5adab602ed12bfc71b744ff0241 -> repairnator/failingProject -> nofixes
         Launcher launcher = new Launcher(new String[]{
                 "--sequencerRepair",
                 "--gitrepo",
-                "--gitrepourl", "https://github.com/javierron/failingProject",
+                "--gitrepourl", "https://github.com/repairnator/failingProject",
                 "--gitrepoidcommit", "e182ccb9ef41b5adab602ed12bfc71b744ff0241",
                 "--launcherMode", "SEQUENCER_REPAIR",
                 "--workspace", workspaceFolder.getRoot().getAbsolutePath(),
@@ -77,14 +75,12 @@ public class TestPipelineSequencerRepair {
 
     @Test
     public void TestPipelineBuildFailBranch() throws Exception{
-        // 713361530 -> repairnator/failingProject -> syntax error
+        // ec915681fbd6a8b2c30580b2618e62636204abe4 -> repairnator/failingProject -> syntax error
         Launcher launcher = new Launcher(new String[]{
-                "--jtravisendpoint", "https://api.travis-ci.com",
-                "--build", "220941672",
-                "--sequencerRepair",
                 "--gitrepo",
-                "--gitrepourl", "https://github.com/javierron/failingProject",
+                "--gitrepourl", "https://github.com/repairnator/failingProject",
                 "--gitrepoidcommit", "ec915681fbd6a8b2c30580b2618e62636204abe4",
+                "--sequencerRepair",
                 "--launcherMode", "SEQUENCER_REPAIR",
                 "--workspace", workspaceFolder.getRoot().getAbsolutePath(),
                 "--output", outputFolder.getRoot().getAbsolutePath()

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/TestGlobalPatchAnalysis.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/TestGlobalPatchAnalysis.java
@@ -47,7 +47,7 @@ public class TestGlobalPatchAnalysis {
 	public void setup() {
 		RepairnatorConfig config = RepairnatorConfig.getInstance();
 		config.setZ3solverPath(Utils4Tests.getZ3SolverPath());
-		//config.setJTravisEndpoint("https://api.travis-ci.com");
+		config.setJTravisEndpoint("https://api.travis-ci.com");
 	}
 
 	@After
@@ -121,7 +121,7 @@ public class TestGlobalPatchAnalysis {
 		RepairnatorConfig.getInstance().setPatchClassification(true);
 		RepairnatorConfig.getInstance().setPatchClassificationMode(RepairnatorConfig.PATCH_CLASSIFICATION_MODE.ODS);
 
-		long buildId = 203797975; // fermadeiral/TestingProject build
+		long buildId = 225936611; // https://travis-ci.com/github/repairnator/TestingProject/builds/225936611
 		Build build = this.checkBuildAndReturn(buildId, false);
 
 		tmpDir = Files.createTempDirectory("patch_classification").toFile();

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/TestProjectInspector4Bears.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/TestProjectInspector4Bears.java
@@ -66,6 +66,7 @@ public class TestProjectInspector4Bears {
         config.setPushRemoteRepo("");
         config.setGithubUserEmail("noreply@github.com");
         config.setGithubUserName("repairnator");
+        config.setJTravisEndpoint("https://api.travis-ci.com");
         Utils.setLoggersLevel(Level.ERROR);
 
         serializerEngine = mock(SerializerEngine.class);
@@ -88,8 +89,8 @@ public class TestProjectInspector4Bears {
 
     @Test
     public void testFailingPassingProject() throws IOException, GitAPIException {
-        long buildIdPassing = 203800961;
-        long buildIdFailing = 203797975;
+        long buildIdPassing = 226012005; // https://travis-ci.com/github/repairnator/TestingProject/builds/226012005
+        long buildIdFailing = 225936611; // https://travis-ci.com/github/repairnator/TestingProject/builds/225936611
 
         tmpDir = Files.createTempDirectory("test_bears1").toFile();
 
@@ -142,8 +143,8 @@ public class TestProjectInspector4Bears {
 
     @Test
     public void testPassingPassingProject() throws IOException, GitAPIException {
-        long buildIdPassing = 201938881;
-        long buildIdPreviousPassing = 201938325;
+        long buildIdPassing = 226012099; // https://travis-ci.com/github/repairnator/TestingProject/builds/226012099
+        long buildIdPreviousPassing = 226012117; // https://travis-ci.com/github/repairnator/TestingProject/builds/226012117
 
         tmpDir = Files.createTempDirectory("test_bears2").toFile();
 

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/metrics4bears/TestMetrics4BearsJsonFile.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/metrics4bears/TestMetrics4BearsJsonFile.java
@@ -95,12 +95,6 @@ public class TestMetrics4BearsJsonFile {
         FileHelper.deleteFile(tmpDir);
     }
 
-    /*
-     FIXME: Previous error was fixed. Path to bears-chema.json is now working.
-     Current issue is that the json file that the result is compared to isn't reproducible.
-     One way to fix the issue would be to set the JSON comparison to LENIENT, and edit the json to contain only the parts that never change between runs.
-     */
-    @Ignore
     @Test
     public void testBearsJsonFileWithPassingPassingBuilds() throws IOException, ProcessingException {
         long buggyBuildCandidateId = 225920540; // https://travis-ci.com/github/repairnator/test-repairnator-bears/builds/225920540
@@ -159,7 +153,7 @@ public class TestMetrics4BearsJsonFile {
             String fieldComparisonFailureName = fieldComparisonFailure.getField();
             if (fieldComparisonFailureName.equals("tests.failingModule") ||
                     fieldComparisonFailureName.equals("reproductionBuggyBuild.projectRootPomPath")) {
-                String path = "repairnator/test-repairnator-bears/386337343";
+                String path = "repairnator/test-repairnator-bears";
                 String expected = (String) fieldComparisonFailure.getExpected();
                 expected = expected.substring(expected.indexOf(path), expected.length());
                 String actual = (String) fieldComparisonFailure.getActual();
@@ -175,14 +169,9 @@ public class TestMetrics4BearsJsonFile {
         }
     }
 
-    /*
-     FIXME: See message of the previous test. Plus, the buildId isn't on travis.com and it has been deleted from travis.org
-     To fix this, another build needs to replace this one, so results may be different.
-     */
-    @Ignore
     @Test
     public void testRepairnatorJsonFileWithFailingBuild() throws IOException, ProcessingException {
-        long buggyBuildCandidateId = 208897371; // https://travis-ci.org/surli/failingProject/builds/208897371
+        long buggyBuildCandidateId = 220944190; // https://travis-ci.com/github/repairnator/failingProject/builds/220944190
 
         tmpDir = Files.createTempDirectory("test_repairnator_json_file_failing_build").toFile();
 
@@ -194,7 +183,7 @@ public class TestMetrics4BearsJsonFile {
         config.setLauncherMode(LauncherMode.REPAIR);
         config.setRepairTools(new HashSet<>(Arrays.asList("NopolSingleTest")));
 
-        ProjectInspector inspector = new ProjectInspector(buildToBeInspected, tmpDir.getAbsolutePath(), null, null);
+        ProjectInspector inspector = InspectorFactory.getTravisInspector(buildToBeInspected, tmpDir.getAbsolutePath(), null);
         inspector.run();
 
         // check repairnator.json against schema
@@ -235,9 +224,15 @@ public class TestMetrics4BearsJsonFile {
 
         for (FieldComparisonFailure fieldComparisonFailure : result.getFieldFailures()) {
             String fieldComparisonFailureName = fieldComparisonFailure.getField();
-            if (fieldComparisonFailureName.equals("tests.failingModule") ||
+            if (fieldComparisonFailureName.equals("tests.failureDetails[0].detail")) {
+                String expected = (String) fieldComparisonFailure.getExpected();
+                String actual = (String) fieldComparisonFailure.getActual();
+                assertTrue("Property failing: " + fieldComparisonFailureName,
+                        actual.replaceAll("\\s+", "")
+                                .equals(expected.replaceAll("\\s+", "")));
+            } else if (fieldComparisonFailureName.equals("tests.failingModule") ||
                     fieldComparisonFailureName.equals("reproductionBuggyBuild.projectRootPomPath")) {
-                String path = "surli/failingProject/208897371";
+                String path = "repairnator/failingProject";
                 String expected = (String) fieldComparisonFailure.getExpected();
                 expected = expected.substring(expected.indexOf(path), expected.length());
                 String actual = (String) fieldComparisonFailure.getActual();

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/metrics4bears/TestMetrics4BearsJsonFile.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/metrics4bears/TestMetrics4BearsJsonFile.java
@@ -39,8 +39,7 @@ import java.util.*;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class TestMetrics4BearsJsonFile {
 
@@ -61,6 +60,7 @@ public class TestMetrics4BearsJsonFile {
         config.setZ3solverPath(Utils4Tests.getZ3SolverPath());
         config.setGithubUserEmail("noreply@github.com");
         config.setGithubUserName("repairnator");
+        config.setJTravisEndpoint("https://api.travis-ci.com");
 
         propertiesToIgnore = new ArrayList<>();
         propertiesToIgnore.add("reproductionBuggyBuild.reproductionDateBeginning");
@@ -95,13 +95,16 @@ public class TestMetrics4BearsJsonFile {
         FileHelper.deleteFile(tmpDir);
     }
 
-    // FIXME: this is critical: such test case results in error when running in Travis, but locally, running only this test, the test passes.
-    // Error presented in the Travis log: TestMetrics4BearsJsonFile.testBearsJsonFileWithPassingPassingBuilds:128 » FileNotFound
+    /*
+     FIXME: Previous error was fixed. Path to bears-chema.json is now working.
+     Current issue is that the json file that the result is compared to isn't reproducible.
+     One way to fix the issue would be to set the JSON comparison to LENIENT, and edit the json to contain only the parts that never change between runs.
+     */
     @Ignore
     @Test
     public void testBearsJsonFileWithPassingPassingBuilds() throws IOException, ProcessingException {
-        long buggyBuildCandidateId = 386337343; // https://travis-ci.org/fermadeiral/test-repairnator-bears/builds/386337343
-        long patchedBuildCandidateId = 386348522; // https://travis-ci.org/fermadeiral/test-repairnator-bears/builds/386348522
+        long buggyBuildCandidateId = 225920540; // https://travis-ci.com/github/repairnator/test-repairnator-bears/builds/225920540
+        long patchedBuildCandidateId = 225920529; // https://travis-ci.com/github/repairnator/test-repairnator-bears/builds/225920529
 
         tmpDir = Files.createTempDirectory("test_bears_json_file_passing_passing_builds").toFile();
 
@@ -120,7 +123,7 @@ public class TestMetrics4BearsJsonFile {
 
         ObjectMapper jsonMapper = new ObjectMapper();
         String workingDir = System.getProperty("user.dir");
-        workingDir = workingDir.substring(0, workingDir.lastIndexOf("repairnator/"));
+        workingDir = workingDir.substring(0, workingDir.lastIndexOf("repairnator/") + "repairnator/".length());
         String jsonSchemaFilePath = workingDir + "resources/bears-schema.json";
         File jsonSchemaFile = new File(jsonSchemaFilePath);
         JsonNode schemaObject = jsonMapper.readTree(jsonSchemaFile);
@@ -156,7 +159,7 @@ public class TestMetrics4BearsJsonFile {
             String fieldComparisonFailureName = fieldComparisonFailure.getField();
             if (fieldComparisonFailureName.equals("tests.failingModule") ||
                     fieldComparisonFailureName.equals("reproductionBuggyBuild.projectRootPomPath")) {
-                String path = "fermadeiral/test-repairnator-bears/386337343";
+                String path = "repairnator/test-repairnator-bears/386337343";
                 String expected = (String) fieldComparisonFailure.getExpected();
                 expected = expected.substring(expected.indexOf(path), expected.length());
                 String actual = (String) fieldComparisonFailure.getActual();
@@ -172,6 +175,10 @@ public class TestMetrics4BearsJsonFile {
         }
     }
 
+    /*
+     FIXME: See message of the previous test. Plus, the buildId isn't on travis.com and it has been deleted from travis.org
+     To fix this, another build needs to replace this one, so results may be different.
+     */
     @Ignore
     @Test
     public void testRepairnatorJsonFileWithFailingBuild() throws IOException, ProcessingException {
@@ -194,7 +201,7 @@ public class TestMetrics4BearsJsonFile {
 
         ObjectMapper jsonMapper = new ObjectMapper();
         String workingDir = System.getProperty("user.dir");
-        workingDir = workingDir.substring(0, workingDir.lastIndexOf("repairnator/"));
+        workingDir = workingDir.substring(0, workingDir.lastIndexOf("repairnator/") + "repairnator/".length());
         String jsonSchemaFilePath = workingDir + "resources/repairnator-schema.json";
         File jsonSchemaFile = new File(jsonSchemaFilePath);
         JsonNode schemaObject = jsonMapper.readTree(jsonSchemaFile);

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/metrics4bears/TestMetrics4BearsJsonFile.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/metrics4bears/TestMetrics4BearsJsonFile.java
@@ -117,8 +117,14 @@ public class TestMetrics4BearsJsonFile {
 
         ObjectMapper jsonMapper = new ObjectMapper();
         String workingDir = System.getProperty("user.dir");
-        workingDir = workingDir.substring(0, workingDir.lastIndexOf("repairnator/") + "repairnator/".length());
-        String jsonSchemaFilePath = workingDir + "resources/bears-schema.json";
+        // In CI the base dir has a diferent name, and it changes with the PR
+        if (workingDir.contains("repairnator/")) {
+            workingDir = workingDir.substring(0, workingDir.lastIndexOf("repairnator/") + "repairnator/".length());
+        } else {
+            // We use the stable part (i.e. the sub-module) to get the workingDir
+            workingDir = workingDir.substring(0, workingDir.lastIndexOf("src/repairnator-pipeline"));
+        }
+        String jsonSchemaFilePath = workingDir + "/resources/bears-schema.json";
         File jsonSchemaFile = new File(jsonSchemaFilePath);
         JsonNode schemaObject = jsonMapper.readTree(jsonSchemaFile);
 
@@ -190,8 +196,14 @@ public class TestMetrics4BearsJsonFile {
 
         ObjectMapper jsonMapper = new ObjectMapper();
         String workingDir = System.getProperty("user.dir");
-        workingDir = workingDir.substring(0, workingDir.lastIndexOf("repairnator/") + "repairnator/".length());
-        String jsonSchemaFilePath = workingDir + "resources/repairnator-schema.json";
+        // In CI the base dir has a diferent name, and it changes with the PR
+        if (workingDir.contains("repairnator/")) {
+            workingDir = workingDir.substring(0, workingDir.lastIndexOf("repairnator/") + "repairnator/".length());
+        } else {
+            // We use the stable part (i.e. the sub-module) to get the workingDir
+            workingDir = workingDir.substring(0, workingDir.lastIndexOf("src/repairnator-pipeline"));
+        }
+        String jsonSchemaFilePath = workingDir + "/resources/repairnator-schema.json";
         File jsonSchemaFile = new File(jsonSchemaFilePath);
         JsonNode schemaObject = jsonMapper.readTree(jsonSchemaFile);
 

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/metrics4bears/TestMetrics4BearsJsonFile.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/inspectors/metrics4bears/TestMetrics4BearsJsonFile.java
@@ -175,6 +175,10 @@ public class TestMetrics4BearsJsonFile {
         }
     }
 
+    // FIXME: This test is working locally, but there is an issue with the repoToPushLocalPath when running in CI.
+    // As far as I understood, it is using the repoToPushLocalPath from another test (TestProjectInspector#testPatchFailingProject)
+    // but wasn't able to fix it.
+    @Ignore
     @Test
     public void testRepairnatorJsonFileWithFailingBuild() throws IOException, ProcessingException {
         long buggyBuildCandidateId = 220944190; // https://travis-ci.com/github/repairnator/failingProject/builds/220944190

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/TestGatherTestInformation.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/TestGatherTestInformation.java
@@ -267,8 +267,7 @@ public class TestGatherTestInformation {
 
     @Test
     public void testGatherTestInformationWhenNotFailing() throws IOException {
-        RepairnatorConfig.getInstance().setJTravisEndpoint("https://api.travis-ci.org");
-        long buildId = 201176013; // fermadeiral/TestingProject
+        long buildId = 225938152; // https://travis-ci.com/github/repairnator/TestingProject/builds/225938152
 
         Build build = this.checkBuildAndReturn(buildId, false);
 
@@ -323,8 +322,7 @@ public class TestGatherTestInformation {
 
     @Test
     public void testGatherTestInformationWhenNotFailingWithPassingContract() throws IOException {
-        RepairnatorConfig.getInstance().setJTravisEndpoint("https://api.travis-ci.org");
-        long buildId = 201176013; // fermadeiral/TestingProject
+        long buildId = 225938152; // https://travis-ci.com/github/repairnator/TestingProject/builds/225938152
 
         Build build = this.checkBuildAndReturn(buildId, false);
 

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/TestTestProject.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/TestTestProject.java
@@ -112,8 +112,7 @@ public class TestTestProject {
 
     @Test
     public void testTestProjectWhenNotFailing() throws IOException {
-        RepairnatorConfig.getInstance().setJTravisEndpoint("https://api.travis-ci.org");
-        long buildId = 201176013; // fermadeiral/TestingProject
+        long buildId = 225938152; // https://travis-ci.com/github/repairnator/TestingProject/builds/225938152
 
         Build build = this.checkBuildAndReturn(buildId, false);
 

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/paths/TestComputeClasspath.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/paths/TestComputeClasspath.java
@@ -99,7 +99,7 @@ public class TestComputeClasspath {
 
     @Test
     public void testComputeClasspathWithMultiModuleProject() throws IOException {
-        long buggyBuildCandidateId = 224302680; // andre15silva/test-repairnator-bears (this is temporary until the project is moved to the repairnator org)
+        long buggyBuildCandidateId = 225920529; // https://travis-ci.com/github/repairnator/test-repairnator-bears/builds/225920529
 
         Build buggyBuildCandidate = this.checkBuildAndReturn(buggyBuildCandidateId, false);
 

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/paths/TestComputeTestDir.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/paths/TestComputeTestDir.java
@@ -52,7 +52,7 @@ public class TestComputeTestDir {
 
     @Test
     public void testComputeTestDirWithMultiModuleProject() throws IOException {
-        long buggyBuildCandidateId = 224302680; // andre15silva/test-repairnator-bears (this is temporary until the project is moved to the repairnator org)
+        long buggyBuildCandidateId = 225920529; // https://travis-ci.com/github/repairnator/test-repairnator-bears/builds/225920529
 
         Build buggyBuildCandidate = this.checkBuildAndReturn(buggyBuildCandidateId, false);
 

--- a/src/repairnator-pipeline/src/test/resources/json-files/bears-386337343-386348522.json
+++ b/src/repairnator-pipeline/src/test/resources/json-files/bears-386337343-386348522.json
@@ -2,9 +2,9 @@
   "version": "Bears 1.0",
   "type": "passing_passing",
   "repository": {
-    "name": "fermadeiral/test-repairnator-bears",
+    "name": "repairnator/test-repairnator-bears",
     "githubId": 135598437,
-    "url": "https://github.com/fermadeiral/test-repairnator-bears",
+    "url": "https://github.com/repairnator/test-repairnator-bears",
     "isFork": false,
     "original": {
       "name": "",
@@ -16,34 +16,34 @@
   },
   "builds": {
     "buggyBuild": {
-      "id": 386337343,
-      "url": "http://travis-ci.org/fermadeiral/test-repairnator-bears/builds/386337343",
-      "date": "May 31, 2018 4:33:25 PM"
+      "id": 225920540,
+      "url": "http://travis-ci.org/repairnator/test-repairnator-bears/builds/225920540",
+      "date": "May 14, 2021, 11:10:26 AM"
     },
     "fixerBuild": {
-      "id": 386348522,
-      "url": "http://travis-ci.org/fermadeiral/test-repairnator-bears/builds/386348522",
-      "date": "May 31, 2018 5:01:06 PM"
+      "id": 225920529,
+      "url": "http://travis-ci.org/repairnator/test-repairnator-bears/builds/225920529",
+      "date": "May 14, 2021, 11:10:18 AM"
     }
   },
   "commits": {
     "buggyBuild": {
-      "repoName": "fermadeiral/test-repairnator-bears",
+      "repoName": "repairnator/test-repairnator-bears",
       "branchName": "master",
       "sha": "bfdf6af10937db8ecde7a060b55d18864663abd5",
-      "url": "http://github.com/fermadeiral/test-repairnator-bears/commit/bfdf6af10937db8ecde7a060b55d18864663abd5",
+      "url": "http://github.com/repairnator/test-repairnator-bears/commit/bfdf6af10937db8ecde7a060b55d18864663abd5",
       "date": "May 31, 2018 4:32:11 PM"
     },
     "fixerBuild": {
-      "repoName": "fermadeiral/test-repairnator-bears",
+      "repoName": "repairnator/test-repairnator-bears",
       "branchName": "master",
       "sha": "5b2ed0064d4c5e0fade39125cc071bd6593df869",
-      "url": "http://github.com/fermadeiral/test-repairnator-bears/commit/5b2ed0064d4c5e0fade39125cc071bd6593df869",
+      "url": "http://github.com/repairnator/test-repairnator-bears/commit/5b2ed0064d4c5e0fade39125cc071bd6593df869",
       "date": "May 31, 2018 4:59:52 PM"
     }
   },
   "tests": {
-    "failingModule": "/tmp/test_bears_json_file_passing_passing_builds4300363164793498124/fermadeiral/test-repairnator-bears/386337343/test-repairnator-bears-patchstats",
+    "failingModule": "/tmp/test_bears_json_file_passing_passing_builds4300363164793498124/repairnator/test-repairnator-bears/test-repairnator-bears-patchstats",
     "overallMetrics": {
       "numberRunning": 9,
       "numberPassing": 8,
@@ -73,7 +73,7 @@
         "testClass": "PatchStatsTest",
         "testMethod": "testComputeFilesWithCommitThatRenameFile",
         "failureName": "java.lang.AssertionError",
-        "detail": "expected:\u003c10\u003e but was:\u003c9\u003e",
+        "detail": "java.lang.AssertionError: expected:\u003c10\u003e but was:\u003c9\u003e\n\tat org.junit.Assert.fail(Assert.java:88)\n\tat org.junit.Assert.failNotEquals(Assert.java:834)\n\tat org.junit.Assert.assertEquals(Assert.java:645)\n\tat org.junit.Assert.assertEquals(Assert.java:631)\n\tat PatchStatsTest.testComputeFilesWithCommitThatRenameFile(PatchStatsTest.java:62)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\n\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)\n\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)\n\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n\tat org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)\n\tat org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)\n\tat org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)\n\tat org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)\n\tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)\n\tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)\n\tat org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)\n\tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)\n\tat org.junit.runners.ParentRunner.run(ParentRunner.java:363)\n\tat org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)\n\tat org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)\n\tat org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\n\tat org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)\n\tat org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)\n\tat org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)\n\tat org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)\n\tat org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)",
         "isError": false
       }
     ]
@@ -91,6 +91,7 @@
   },
   "projectMetrics": {
     "numberModules": 2,
+    "numberPlugins": 0,
     "numberSourceFiles": 2,
     "numberTestFiles": 3,
     "numberLibrariesFailingModule": 4,
@@ -146,6 +147,6 @@
         ]
       }
     },
-    "projectRootPomPath": "/tmp/test_bears_json_file_passing_passing_builds4300363164793498124/fermadeiral/test-repairnator-bears/386337343/pom.xml"
+    "projectRootPomPath": "/tmp/test_bears_json_file_passing_passing_builds4300363164793498124/repairnator/test-repairnator-bears/pom.xml"
   }
 }

--- a/src/repairnator-pipeline/src/test/resources/json-files/repairnator-208897371.json
+++ b/src/repairnator-pipeline/src/test/resources/json-files/repairnator-208897371.json
@@ -1,9 +1,9 @@
 {
   "type": "only_fail",
   "repository": {
-    "name": "surli/failingProject",
-    "githubId": 78415513,
-    "url": "https://github.com/surli/failingProject",
+    "name": "repairnator/failingProject",
+    "githubId": 345049665,
+    "url": "https://github.com/repairnator/failingProject",
     "isFork": false,
     "original": {
       "name": "",
@@ -15,22 +15,22 @@
   },
   "builds": {
     "buggyBuild": {
-      "id": 208897371,
-      "url": "http://travis-ci.org/surli/failingProject/builds/208897371",
-      "date": "Mar 8, 2017 4:07:02 AM"
+      "id": 220944190,
+      "url": "http://travis-ci.org/repairnator/failingProject/builds/220944190",
+      "date": "Mar 23, 2021, 10:44:24 AM"
     }
   },
   "commits": {
     "buggyBuild": {
-      "repoName": "surli/failingProject",
+      "repoName": "repairnator/failingProject",
       "branchName": "only-one-failing",
       "sha": "e17771af92490121d4b1655c0bdf36b3692f1ce3",
-      "url": "http://github.com/surli/failingProject/commit/e17771af92490121d4b1655c0bdf36b3692f1ce3",
+      "url": "http://github.com/repairnator/failingProject/commit/e17771af92490121d4b1655c0bdf36b3692f1ce3",
       "date": "Mar 8, 2017 4:05:44 AM"
     }
   },
   "tests": {
-    "failingModule": "/tmp/test_bears_json_file_failing_build4879665694333003261/surli/failingProject/208897371",
+    "failingModule": "/tmp/test_bears_json_file_failing_build4879665694333003261/repairnator/failingProject",
     "overallMetrics": {
       "numberRunning": 8,
       "numberPassing": 7,
@@ -60,7 +60,7 @@
         "testClass": "nopol_examples.nopol_example_1.NopolExampleTest",
         "testMethod": "test5",
         "failureName": "java.lang.StringIndexOutOfBoundsException",
-        "detail": "String index out of range: -5",
+        "detail": "java.lang.StringIndexOutOfBoundsException: String index out of range: -5\n\tat java.base/java.lang.StringLatin1.charAt(StringLatin1.java:47)\n\tat java.base/java.lang.String.charAt(String.java:693)\n\tat nopol_examples.nopol_example_1.NopolExample.charAt(NopolExample.java:16)\n\tat nopol_examples.nopol_example_1.NopolExampleTest.test5(NopolExampleTest.java:39)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\n\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)\n\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)\n\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n\tat org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)\n\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)\n\tat org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)\n\tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)\n\tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)\n\tat org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)\n\tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)\n\tat org.junit.runners.ParentRunner.run(ParentRunner.java:309)\n\tat org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)\n\tat org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)\n\tat org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\n\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\n\tat org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)\n\tat org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)\n\tat org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)\n\tat org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)\n\tat org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)",
         "isError": true
       }
     ]
@@ -78,6 +78,7 @@
   },
   "projectMetrics": {
     "numberModules": 1,
+    "numberPlugins": 0,
     "numberSourceFiles": 10,
     "numberTestFiles": 1,
     "numberLibrariesFailingModule": 2,
@@ -137,6 +138,6 @@
         ]
       }
     },
-    "projectRootPomPath": "/tmp/test_bears_json_file_failing_build4879665694333003261/surli/failingProject/208897371/pom.xml"
+    "projectRootPomPath": "/tmp/test_bears_json_file_failing_build4879665694333003261/repairnator/failingProject/pom.xml"
   }
 }

--- a/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestGithubScanner.java
+++ b/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestGithubScanner.java
@@ -28,8 +28,8 @@ public class TestGithubScanner {
         Whitebox.setInternalState(scanner, "runner", runner);
 
         boolean isGithubActionsFailed = false;
-        String commitId = "65eb0ee8cc221bd4fe6d6414feb6ee368131288d";
-        String repoName = "javierron/failingProject";
+        String commitId = "fda5d6161a5602a76e810209491d04cf91f4803b";
+        String repoName = "repairnator/failingProject";
         SelectedCommit commit = new SelectedCommit(isGithubActionsFailed, commitId, repoName);
 
         scanner.process(commit);

--- a/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestRTScanner.java
+++ b/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestRTScanner.java
@@ -24,7 +24,7 @@ public class TestRTScanner {
     
     @Test
     public void testRepositoryWithoutSuccessfulBuildIsNotInteresting() {
-        String slug = "surli/failingProject";
+        String slug = "repairnator/failingProject";
         RepairnatorConfig.getInstance().setLauncherMode(LauncherMode.REPAIR);
         Optional<Repository> repositoryOptional = getOptionalRepository(slug);
 
@@ -35,7 +35,7 @@ public class TestRTScanner {
 
     @Test
     public void testRepositoryWithoutCheckstyleIsNotInteresting() {
-        String slug = "surli/test-repairnator";
+        String slug = "repairnator/test-repairnator";
         RepairnatorConfig.getInstance().setLauncherMode(LauncherMode.CHECKSTYLE);
         Optional<Repository> repositoryOptional = getOptionalRepository(slug);
 

--- a/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestZeroScanner.java
+++ b/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestZeroScanner.java
@@ -34,6 +34,9 @@ public class TestZeroScanner {
 
     @Before
     public void setup() {
+        RepairnatorConfig config = RepairnatorConfig.getInstance();
+        config.setJTravisEndpoint("https://api.travis-ci.com");
+
         build = new Build();
         buildV2 = new BuildV2();
         buildV2.setCommit(new Commit());
@@ -55,13 +58,13 @@ public class TestZeroScanner {
 
     @Test
     public void TestAttemptJob () {
-        scanner.attemptJob(702053045); //failing job
+        scanner.attemptJob(224246334); // failing job - https://travis-ci.com/github/repairnator/failingProject/builds/224246334
         verify(rtScanner, times(1)).submitBuildToExecution(any(Build.class));
     }
 
     @Test
     public void TestCollectJob () {
-        scanner.collectJob(704352008, "javierron/failingProject"); //passing job
+        scanner.collectJob(220482792, "repairnator/failingProject"); // passing job - https://travis-ci.com/github/repairnator/failingProject/builds/220482792
         verify(collector, times(1)).handle(anyString(), anyString());
     }
 


### PR DESCRIPTION
## Changelog
- Move tests from external repos to internal repos
- Move test builds from `travis-ci.org` to `travis-ci.com`
- Fixed and reactivated test from `TestMetrics4BearsJsonFile.java`. The other one works locally but fails in CI (see #1219).

## TODO
- Move https://github.com/henry-lp/SonarQubeRepairTests to internal org and update