### PR TITLE
test: update tests to make CI green again

### DIFF
--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipelineb/TestPipelinebGithubMode.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipelineb/TestPipelinebGithubMode.java
@@ -68,8 +68,7 @@ public class TestPipelinebGithubMode {
         GithubMainProcess mainProc = (GithubMainProcess) MainProcessFactory.getGithubMainProcess(new String[]{
                 "--gitrepo",
                 "--gitrepourl", "https://github.com/repairnator/failingProject",
-                "--gitrepoidcommit", "883bc40f01902654b1b1df094b2badb28e192097",
-                "--gitrepobranch", "nofixes",
+                "--gitrepobranch", "master",
                 "--workspace", workspaceFolder.getRoot().getAbsolutePath(),
                 "--output", outputFolder.getRoot().getAbsolutePath()
         });

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipelineb/TestPipelinebGithubMode.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipelineb/TestPipelinebGithubMode.java
@@ -68,7 +68,7 @@ public class TestPipelinebGithubMode {
         GithubMainProcess mainProc = (GithubMainProcess) MainProcessFactory.getGithubMainProcess(new String[]{
                 "--gitrepo",
                 "--gitrepourl", "https://github.com/repairnator/failingProject",
-                "--gitrepobranch", "master",
+                "--gitrepobranch", "no-infinite-loop",
                 "--workspace", workspaceFolder.getRoot().getAbsolutePath(),
                 "--output", outputFolder.getRoot().getAbsolutePath()
         });

--- a/src/repairnator-realtime/pom.xml
+++ b/src/repairnator-realtime/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.116</version>
+            <version>1.130</version>
         </dependency>
     </dependencies>
 

--- a/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestGithubScanner.java
+++ b/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestGithubScanner.java
@@ -3,7 +3,6 @@ package fr.inria.spirals.repairnator.realtime;
 import fr.inria.spirals.repairnator.InputBuild;
 import fr.inria.spirals.repairnator.realtime.githubapi.commits.models.SelectedCommit;
 import org.apache.commons.io.FileUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static junit.framework.TestCase.*;
@@ -38,7 +37,6 @@ public class TestGithubScanner {
     }
 
     @Test
-    @Ignore
     public void testFetchingAll() throws Exception {
 
         Set<String> repos = new HashSet<String>(FileUtils.readLines(new File(getClass()
@@ -54,7 +52,6 @@ public class TestGithubScanner {
     }
 
     @Test
-    @Ignore
     public void testFetchingFailed() throws Exception {
 
         Set<String> repos = new HashSet<String>(FileUtils.readLines(new File(getClass()
@@ -70,7 +67,6 @@ public class TestGithubScanner {
     }
 
     @Test
-    @Ignore
     public void testFetchingPassing() throws Exception {
 
         Set<String> repos = new HashSet<String>(FileUtils.readLines(new File(getClass()

--- a/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestGithubScanner.java
+++ b/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestGithubScanner.java
@@ -3,6 +3,7 @@ package fr.inria.spirals.repairnator.realtime;
 import fr.inria.spirals.repairnator.InputBuild;
 import fr.inria.spirals.repairnator.realtime.githubapi.commits.models.SelectedCommit;
 import org.apache.commons.io.FileUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static junit.framework.TestCase.*;
@@ -37,6 +38,7 @@ public class TestGithubScanner {
     }
 
     @Test
+    @Ignore
     public void testFetchingAll() throws Exception {
 
         Set<String> repos = new HashSet<String>(FileUtils.readLines(new File(getClass()
@@ -52,6 +54,7 @@ public class TestGithubScanner {
     }
 
     @Test
+    @Ignore
     public void testFetchingFailed() throws Exception {
 
         Set<String> repos = new HashSet<String>(FileUtils.readLines(new File(getClass()
@@ -67,6 +70,7 @@ public class TestGithubScanner {
     }
 
     @Test
+    @Ignore
     public void testFetchingPassing() throws Exception {
 
         Set<String> repos = new HashSet<String>(FileUtils.readLines(new File(getClass()

--- a/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestRTScanner.java
+++ b/src/repairnator-realtime/src/test/java/fr/inria/spirals/repairnator/realtime/TestRTScanner.java
@@ -48,6 +48,7 @@ public class TestRTScanner {
     public void testRepositoryWithoutCheckstyleIsInteresting() {
         String slug = "repairnator/embedded-cassandra";
         RepairnatorConfig.getInstance().setLauncherMode(LauncherMode.CHECKSTYLE);
+        RepairnatorConfig.getInstance().setJTravisEndpoint("https://api.travis-ci.org");
         Optional<Repository> repositoryOptional = getOptionalRepository(slug);
 
         RTScanner rtScanner = new RTScanner("test", new ArrayList<>());


### PR DESCRIPTION
- Updated GithubScanner tests, as a [change on the GitHub API broke the API library we use and later was fixed.](https://github.com/hub4j/github-api/issues/1156)
- Specified target endpoint on testRepositoryWithoutCheckstyleIsNotInteresting() to avoid flakiness
- Changed target build in testPipelineGitRepositoryAndCommitIdWithFailure() to avoid flakiness  #1176