### PR TITLE
Fault localization mode

### DIFF
--- a/doc/main-classes.md
+++ b/doc/main-classes.md
@@ -190,6 +190,21 @@ export TOOLS_JAR=/usr/lib/jvm/default-java/lib/tools.jar
 java -cp $TOOLS_JAR:target/repairnator-pipeline-3.3-SNAPSHOT-jar-with-dependencies.jar fr.inria.spirals.repairnator.pipeline.Launcher --ghOauth $GITHUB_TOKEN --launcherMode GIT_REPOSITORY --gitrepourl <git-repository-url> --gitrepobranch <branch-name>
 ```
 
+### Fault localization mode
+
+Repairnator also features a fault localization mode. 
+In this mode, Travis CI builds are analyzed, and the identified suspicious lines are pushed as a PR review/suggestions to the original PR.
+
+The example below shows the usage of this mode:
+
+```bash
+export M2_HOME=/usr/share/maven
+export GITHUB_TOKEN=foobar # your token
+
+java -cp target/repairnator-pipeline-3.3-SNAPSHOT-jar-with-dependencies.jar fr.inria.spirals.repairnator.pipeline.Launcher --launcherMode FAULT_LOCALIZATION --faultLocalization --build 236072272 --flacocoThreshold 0.12 --ghOauth $GITHUB_TOKEN
+```
+
+The result of running this example can be found [here](https://github.com/repairnator/failingProject/pull/7).
 
 ## Realtime Scanner fr.inria.spirals.repairnator.realtime.RTLauncher
 

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
@@ -119,6 +119,9 @@ public class LauncherUtils {
         // --npeRepairStrategy
         jsap.registerParameter(LauncherUtils.defineArgNPERepairStrategy());
 
+        // --flacocoTreshold
+        jsap.registerParameter(LauncherUtils.defineArgFlacocoThreshold());
+
         // --bears
         jsap.registerParameter(LauncherUtils.defineArgBearsMode());
         // --checkstyle
@@ -234,6 +237,8 @@ public class LauncherUtils {
         config.setNPENbIteration(LauncherUtils.getArgNPENbIteration(arguments));
         config.setNPEScope(LauncherUtils.getArgNPEScope(arguments));
         config.setNPERepairStrategy(LauncherUtils.getArgNPERepairStrategy(arguments));
+
+        config.setFlacocoThreshold(LauncherUtils.getArgFlacocoThreshold(arguments));
 
         config.setPatchClassificationMode(LauncherUtils.getArgPatchClassificationMode(arguments));
         config.setPatchClassification(LauncherUtils.getArgPatchClassification(arguments));
@@ -929,6 +934,19 @@ public class LauncherUtils {
 
     public static String getArgNPERepairStrategy(JSAPResult arguments) {
         return arguments.getString("npeRepairStrategy");
+    }
+
+    public static FlaggedOption defineArgFlacocoThreshold() {
+        FlaggedOption opt = new FlaggedOption("flacocoThreshold");
+        opt.setLongFlag("flacocoThreshold");
+        opt.setStringParser(JSAP.DOUBLE_PARSER);
+        opt.setDefault("0.5");
+        opt.setHelp("Threshold for flacoco fault localization");
+        return opt;
+    }
+
+    public static Double getArgFlacocoThreshold(JSAPResult arguments) {
+        return arguments.getDouble("flacocoThreshold");
     }
 
     public static FlaggedOption defineArgODSPath() {

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/LauncherUtils.java
@@ -125,6 +125,8 @@ public class LauncherUtils {
         jsap.registerParameter(LauncherUtils.defineArgCheckstyleMode());
         // --sequencerRepair
         jsap.registerParameter(LauncherUtils.defineArgSequencerRepairMode());
+        // --faultLocalization
+        jsap.registerParameter(LauncherUtils.defineArgFaultLocalizationMode());
 
         // --patchClassification
         jsap.registerParameter(LauncherUtils.defineArgPatchClassification());
@@ -148,6 +150,8 @@ public class LauncherUtils {
             config.setLauncherMode(LauncherMode.CHECKSTYLE);
         } else if (LauncherUtils.getArgSequencerRepairMode(arguments)) {
             config.setLauncherMode(LauncherMode.SEQUENCER_REPAIR);
+        } else if (LauncherUtils.getArgFaultLocalizationMode(arguments)) {
+            config.setLauncherMode(LauncherMode.FAULT_LOCALIZATION);
         } else {
             config.setLauncherMode(LauncherMode.REPAIR);
         }
@@ -309,6 +313,18 @@ public class LauncherUtils {
 
     public static boolean getArgSequencerRepairMode(JSAPResult arguments) {
         return arguments.getBoolean("sequencerRepair");
+    }
+
+    public static Switch defineArgFaultLocalizationMode() {
+        Switch sw = new Switch("faultLocalization");
+        sw.setLongFlag("faultLocalization");
+        sw.setDefault("false");
+        sw.setHelp("This mode allows to use repairnator's fault localization mode.");
+        return sw;
+    }
+
+    public static boolean getArgFaultLocalizationMode(JSAPResult arguments) {
+        return arguments.getBoolean("faultLocalization");
     }
 
     public static Switch defineArgBearsMode() {

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/config/RepairnatorConfig.java
@@ -123,6 +123,8 @@ public class RepairnatorConfig {
     private String npeScope;
     private String npeRepairStrategy;
 
+    private Double flacocoThreshold;
+
     private PATCH_CLASSIFICATION_MODE patchClassificationMode;
     private PATCH_FILTERING_MODE patchFilteringMode;
     private boolean patchClassification;
@@ -773,6 +775,14 @@ public class RepairnatorConfig {
         this.npeRepairStrategy = npeRepairStrategy;
     }
 
+    public Double getFlacocoThreshold() {
+        return flacocoThreshold;
+    }
+
+    public void setFlacocoThreshold(Double flacocoThreshold) {
+        this.flacocoThreshold = flacocoThreshold;
+    }
+
     @Override
     public String toString() {
         String ghToken = this.getGithubToken();
@@ -845,6 +855,7 @@ public class RepairnatorConfig {
                 ", noTravisRepair=" + noTravisRepair +
                 ", jTravisEndpoint=" + jTravisEndpoint +
                 ", travisToken=" + travisToken +
+                ", flacocoThreshold=" + flacocoThreshold +
                 '}';
     }
 

--- a/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/states/LauncherMode.java
+++ b/src/repairnator-core/src/main/java/fr/inria/spirals/repairnator/states/LauncherMode.java
@@ -41,4 +41,9 @@ public enum LauncherMode {
 	 * SEQUENCER_REPAIR: specific pipeline for SequencerRepair repair tool
 	 */
 	SEQUENCER_REPAIR,
+
+	/**
+	 * FAULT_LOCALIZATION: specific pipeline for running fault localization and push its results
+	 */
+	FAULT_LOCALIZATION
 }

--- a/src/repairnator-pipeline/pom.xml
+++ b/src/repairnator-pipeline/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.github.spoonlabs</groupId>
             <artifactId>flacoco</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>1.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>eu.stamp-project</groupId>
             <artifactId>assert-fixer</artifactId>
-            <version>1.0.9-SNAPSHOT</version>
+            <version>1.0.9</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/src/repairnator-pipeline/pom.xml
+++ b/src/repairnator-pipeline/pom.xml
@@ -35,6 +35,17 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.14.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.14.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.12</version>

--- a/src/repairnator-pipeline/pom.xml
+++ b/src/repairnator-pipeline/pom.xml
@@ -19,7 +19,6 @@
                 <enabled>true</enabled>
                 <updatePolicy>always</updatePolicy>
             </snapshots>
-
         </repository>
         <repository>
             <id>tdurieux-maven-repository-release</id>
@@ -29,6 +28,8 @@
         <repository>
             <id>ossrh</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases><enabled>false</enabled></releases>
+            <snapshots><enabled>true</enabled></snapshots>
         </repository>
     </repositories>
 
@@ -37,6 +38,22 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.12</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spoonlabs</groupId>
+            <artifactId>flacoco</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>github-api</artifactId>
+            <version>1.132</version>
         </dependency>
         <dependency>
             <groupId>se.kth.castor</groupId>

--- a/src/repairnator-pipeline/pom.xml
+++ b/src/repairnator-pipeline/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>eu.stamp-project</groupId>
             <artifactId>assert-fixer</artifactId>
-            <version>1.0.8</version>
+            <version>1.0.9-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/src/repairnator-pipeline/pom.xml
+++ b/src/repairnator-pipeline/pom.xml
@@ -40,6 +40,11 @@
             <version>4.5.12</version>
         </dependency>
         <dependency>
+            <groupId>se.kth.castor</groupId>
+            <artifactId>sorald</artifactId>
+            <version>0.3.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.spoonlabs</groupId>
             <artifactId>flacoco</artifactId>
             <version>0.0.1-SNAPSHOT</version>
@@ -54,11 +59,6 @@
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
             <version>1.132</version>
-        </dependency>
-        <dependency>
-            <groupId>se.kth.castor</groupId>
-            <artifactId>sorald</artifactId>
-            <version>0.3.0</version>
         </dependency>
         <dependency>
             <groupId>fr.inria.repairnator</groupId>

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/BranchLauncher.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/BranchLauncher.java
@@ -59,9 +59,6 @@ public class BranchLauncher implements LauncherAPI{
 
 		String launcherMode = jsapResult.getString("launcherMode");
 
-		System.out.println(launcherMode);
-
-
 		if (launcherMode.equals(LauncherMode.REPAIR.name())) {
 			RepairnatorConfig.getInstance().setLauncherMode(LauncherMode.REPAIR);
 			return MainProcessFactory.getTravisMainProcess(args);
@@ -82,7 +79,7 @@ public class BranchLauncher implements LauncherAPI{
 			return MainProcessFactory.getPipelineListenerMainProcess(args);
 		} else if (launcherMode.equals(LauncherMode.FAULT_LOCALIZATION.name())) {
 			RepairnatorConfig.getInstance().setLauncherMode(LauncherMode.FAULT_LOCALIZATION);
-			return MainProcessFactory.getGithubMainProcess(args);
+			return MainProcessFactory.getTravisMainProcess(args);
 		} else {
 			LOGGER.warn("Unknown launcher mode. Please choose the following: REPAIR, BEARS, CHECKSTYLE, GIT_REPOSITORY, KUBERNETES_LISTENER, JENKINS_PLUGIN, FAULT_LOCALIZATION");
 			return null;

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/BranchLauncher.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/BranchLauncher.java
@@ -59,6 +59,8 @@ public class BranchLauncher implements LauncherAPI{
 
 		String launcherMode = jsapResult.getString("launcherMode");
 
+		System.out.println(launcherMode);
+
 
 		if (launcherMode.equals(LauncherMode.REPAIR.name())) {
 			RepairnatorConfig.getInstance().setLauncherMode(LauncherMode.REPAIR);
@@ -78,8 +80,11 @@ public class BranchLauncher implements LauncherAPI{
 		} else if (launcherMode.equals(LauncherMode.KUBERNETES_LISTENER.name())) {
 			RepairnatorConfig.getInstance().setLauncherMode(LauncherMode.KUBERNETES_LISTENER);
 			return MainProcessFactory.getPipelineListenerMainProcess(args);
+		} else if (launcherMode.equals(LauncherMode.FAULT_LOCALIZATION.name())) {
+			RepairnatorConfig.getInstance().setLauncherMode(LauncherMode.FAULT_LOCALIZATION);
+			return MainProcessFactory.getGithubMainProcess(args);
 		} else {
-			LOGGER.warn("Unknown launcher mode. Please choose the following: REPAIR, BEARS, CHECKSTYLE, GIT_REPOSITORY, KUBERNETES_LISTENER, JENKINS_PLUGIN");
+			LOGGER.warn("Unknown launcher mode. Please choose the following: REPAIR, BEARS, CHECKSTYLE, GIT_REPOSITORY, KUBERNETES_LISTENER, JENKINS_PLUGIN, FAULT_LOCALIZATION");
 			return null;
 		}
 	}

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/MainProcessFactory.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/pipeline/MainProcessFactory.java
@@ -183,6 +183,9 @@ public class MainProcessFactory {
 			case SEQUENCER_REPAIR:
 				inspector = InspectorFactory.getSequencerRepairInspector(buildToBeInspected, workspacePath, notifiers);
 				break;
+			case FAULT_LOCALIZATION:
+				inspector = InspectorFactory.getFaultLocalizationInspector(buildToBeInspected, workspacePath, notifiers);
+				break;
 			default:
 				inspector = InspectorFactory.getTravisInspector(buildToBeInspected, workspacePath, notifiers);
 				break;

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/InspectorFactory.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/InspectorFactory.java
@@ -18,13 +18,21 @@ public class InspectorFactory {
 		return new ProjectInspector(buildToBeInspected,workspace,notifiers).setIRunInspector(new RunInspector4SequencerRepair());
 	}
 
+	public static ProjectInspector getFaultLocalizationInspector(BuildToBeInspected buildToBeInspected, String workspace, List<AbstractNotifier> notifiers){
+		return new ProjectInspector(buildToBeInspected,workspace,notifiers).setIRunInspector(new RunInspector4FaultLocalization());
+	}
+
 	public static GitRepositoryProjectInspector getGithubInspector(GithubInputBuild build, boolean isGitRepositoryFirstCommit,
     		String workspace, List<AbstractNotifier> notifiers) {
 		GitRepositoryProjectInspector inspector = new GitRepositoryProjectInspector(build, isGitRepositoryFirstCommit, workspace, notifiers);
 
+		System.out.println(RepairnatorConfig.getInstance());
 		switch (RepairnatorConfig.getInstance().getLauncherMode()){
 			case SEQUENCER_REPAIR:
 				inspector.setIRunInspector(new RunInspector4SequencerRepair());
+				break;
+			case FAULT_LOCALIZATION:
+				inspector.setIRunInspector(new RunInspector4FaultLocalization());
 				break;
 			default:
 				inspector.setIRunInspector(new RunInspector4DefaultGit());

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/InspectorFactory.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/InspectorFactory.java
@@ -26,13 +26,9 @@ public class InspectorFactory {
     		String workspace, List<AbstractNotifier> notifiers) {
 		GitRepositoryProjectInspector inspector = new GitRepositoryProjectInspector(build, isGitRepositoryFirstCommit, workspace, notifiers);
 
-		System.out.println(RepairnatorConfig.getInstance());
 		switch (RepairnatorConfig.getInstance().getLauncherMode()){
 			case SEQUENCER_REPAIR:
 				inspector.setIRunInspector(new RunInspector4SequencerRepair());
-				break;
-			case FAULT_LOCALIZATION:
-				inspector.setIRunInspector(new RunInspector4FaultLocalization());
 				break;
 			default:
 				inspector.setIRunInspector(new RunInspector4DefaultGit());

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/JobStatus.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/JobStatus.java
@@ -7,6 +7,7 @@ import fr.inria.spirals.repairnator.process.inspectors.properties.tests.FailureD
 import fr.inria.spirals.repairnator.process.step.StepStatus;
 import fr.inria.spirals.repairnator.process.testinformation.FailureLocation;
 import fr.inria.spirals.repairnator.states.PushState;
+import fr.spoonlabs.flacoco.api.Suspiciousness;
 import org.apache.maven.model.Plugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +34,11 @@ public class JobStatus {
      * List of patches indexed by the name of the tool to produce them
      */
     private Map<String, List<RepairPatch>> listOfPatches;
+
+    /**
+     * Flacoco results (used in the fault localization mode)
+     */
+    private Map<String, Suspiciousness> flacocoResults;
 
     /**
      * Diagnostic about repair tool on the form of a JsonElement
@@ -319,5 +325,13 @@ public class JobStatus {
             }
         }
         return failureNames;
+    }
+
+    public Map<String, Suspiciousness> getFlacocoResults() {
+        return flacocoResults;
+    }
+
+    public void setFlacocoResults(Map<String, Suspiciousness> flacocoResults) {
+        this.flacocoResults = flacocoResults;
     }
 }

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/JobStatus.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/JobStatus.java
@@ -7,7 +7,9 @@ import fr.inria.spirals.repairnator.process.inspectors.properties.tests.FailureD
 import fr.inria.spirals.repairnator.process.step.StepStatus;
 import fr.inria.spirals.repairnator.process.testinformation.FailureLocation;
 import fr.inria.spirals.repairnator.states.PushState;
-import fr.spoonlabs.flacoco.api.Suspiciousness;
+import fr.spoonlabs.flacoco.api.result.FlacocoResult;
+import fr.spoonlabs.flacoco.api.result.Location;
+import fr.spoonlabs.flacoco.api.result.Suspiciousness;
 import org.apache.maven.model.Plugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,9 +38,9 @@ public class JobStatus {
     private Map<String, List<RepairPatch>> listOfPatches;
 
     /**
-     * Flacoco results (used in the fault localization mode)
+     * Flacoco result (used in the fault localization mode)
      */
-    private Map<String, Suspiciousness> flacocoResults;
+    private FlacocoResult flacocoResult;
 
     /**
      * Diagnostic about repair tool on the form of a JsonElement
@@ -327,11 +329,11 @@ public class JobStatus {
         return failureNames;
     }
 
-    public Map<String, Suspiciousness> getFlacocoResults() {
-        return flacocoResults;
+    public FlacocoResult getFlacocoResult() {
+        return flacocoResult;
     }
 
-    public void setFlacocoResults(Map<String, Suspiciousness> flacocoResults) {
-        this.flacocoResults = flacocoResults;
+    public void setFlacocoResult(FlacocoResult flacocoResult) {
+        this.flacocoResult = flacocoResult;
     }
 }

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/components/RunInspector4FaultLocalization.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/components/RunInspector4FaultLocalization.java
@@ -1,13 +1,15 @@
 package fr.inria.spirals.repairnator.process.inspectors.components;
 
 import fr.inria.spirals.repairnator.notifier.ErrorNotifier;
-import fr.inria.spirals.repairnator.process.inspectors.GitRepositoryProjectInspector;
 import fr.inria.spirals.repairnator.process.inspectors.ProjectInspector;
 import fr.inria.spirals.repairnator.process.step.AbstractStep;
 import fr.inria.spirals.repairnator.process.step.BuildProject;
-import fr.inria.spirals.repairnator.process.step.CloneCheckoutBranchRepository;
+import fr.inria.spirals.repairnator.process.step.CloneRepository;
 import fr.inria.spirals.repairnator.process.step.TestProject;
+import fr.inria.spirals.repairnator.process.step.checkoutrepository.CheckoutBuggyBuild;
 import fr.inria.spirals.repairnator.process.step.faultLocalization.FlacocoLocalization;
+import fr.inria.spirals.repairnator.process.step.gatherinfo.BuildShouldFail;
+import fr.inria.spirals.repairnator.process.step.gatherinfo.GatherTestInformation;
 import fr.inria.spirals.repairnator.process.step.paths.ComputeClasspath;
 import fr.inria.spirals.repairnator.process.step.paths.ComputeSourceDir;
 import fr.inria.spirals.repairnator.process.step.paths.ComputeTestDir;
@@ -17,42 +19,40 @@ import fr.inria.spirals.repairnator.serializer.AbstractDataSerializer;
 public class RunInspector4FaultLocalization extends IRunInspector {
 
     @Override
-    public void run(ProjectInspector inspector_in) {
-        GitRepositoryProjectInspector inspector = (GitRepositoryProjectInspector) inspector_in;
-        if (inspector.getGitRepositoryUrl() != null) {
-            AbstractStep cloneRepo = new CloneCheckoutBranchRepository(inspector);
+    public void run(ProjectInspector inspector) {
+        AbstractStep cloneRepo = new CloneRepository(inspector);
 
-            cloneRepo.addNextStep(new BuildProject(inspector))
-                    .addNextStep(new TestProject(inspector))
-                    .addNextStep(new ComputeClasspath(inspector, false))
-                    .addNextStep(new ComputeSourceDir(inspector, false, false))
-                    .addNextStep(new ComputeTestDir(inspector, true))
-                    .addNextStep(new FlacocoLocalization(inspector, true));
+        cloneRepo
+                .addNextStep(new CheckoutBuggyBuild(inspector, true))
+                .addNextStep(new BuildProject(inspector))
+                .addNextStep(new TestProject(inspector))
+                .addNextStep(new ComputeClasspath(inspector, false))
+                .addNextStep(new ComputeSourceDir(inspector, false, false))
+                .addNextStep(new ComputeTestDir(inspector, true))
+                .addNextStep(new GatherTestInformation(inspector, true, new BuildShouldFail(), false))
+                .addNextStep(new FlacocoLocalization(inspector, true));
 
-            PushFaultLocalizationSuggestions finalStep = new PushFaultLocalizationSuggestions(inspector, true);
-            cloneRepo.addNextStep(finalStep);
-            inspector.setFinalStep(finalStep);
+        PushFaultLocalizationSuggestions finalStep = new PushFaultLocalizationSuggestions(inspector, true);
+        cloneRepo.addNextStep(finalStep);
+        inspector.setFinalStep(finalStep);
 
-            inspector.printPipeline();
+        inspector.printPipeline();
 
-            try {
-                cloneRepo.execute();
-            } catch (Exception e) {
-                inspector.getJobStatus().addStepError("Unknown", e.getMessage());
-                inspector.getLogger().error("Exception catch while executing steps: ", e);
-                inspector.getJobStatus().setFatalError(e);
+        try {
+            cloneRepo.execute();
+        } catch (Exception e) {
+            inspector.getJobStatus().addStepError("Unknown", e.getMessage());
+            inspector.getLogger().error("Exception catch while executing steps: ", e);
+            inspector.getJobStatus().setFatalError(e);
 
-                ErrorNotifier errorNotifier = ErrorNotifier.getInstance();
-                if (errorNotifier != null) {
-                    errorNotifier.observe(inspector);
-                }
-
-                for (AbstractDataSerializer serializer : inspector.getSerializers()) {
-                    serializer.serialize();
-                }
+            ErrorNotifier errorNotifier = ErrorNotifier.getInstance();
+            if (errorNotifier != null) {
+                errorNotifier.observe(inspector);
             }
-        } else {
-            inspector.getLogger().debug("Build " + inspector.getBuggyBuild().getId() + " is not a failing build.");
+
+            for (AbstractDataSerializer serializer : inspector.getSerializers()) {
+                serializer.serialize();
+            }
         }
     }
 }

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/components/RunInspector4FaultLocalization.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/components/RunInspector4FaultLocalization.java
@@ -1,0 +1,58 @@
+package fr.inria.spirals.repairnator.process.inspectors.components;
+
+import fr.inria.spirals.repairnator.notifier.ErrorNotifier;
+import fr.inria.spirals.repairnator.process.inspectors.GitRepositoryProjectInspector;
+import fr.inria.spirals.repairnator.process.inspectors.ProjectInspector;
+import fr.inria.spirals.repairnator.process.step.AbstractStep;
+import fr.inria.spirals.repairnator.process.step.BuildProject;
+import fr.inria.spirals.repairnator.process.step.CloneCheckoutBranchRepository;
+import fr.inria.spirals.repairnator.process.step.TestProject;
+import fr.inria.spirals.repairnator.process.step.faultLocalization.FlacocoLocalization;
+import fr.inria.spirals.repairnator.process.step.paths.ComputeClasspath;
+import fr.inria.spirals.repairnator.process.step.paths.ComputeSourceDir;
+import fr.inria.spirals.repairnator.process.step.paths.ComputeTestDir;
+import fr.inria.spirals.repairnator.process.step.push.PushFaultLocalizationSuggestions;
+import fr.inria.spirals.repairnator.serializer.AbstractDataSerializer;
+
+public class RunInspector4FaultLocalization extends IRunInspector {
+
+    @Override
+    public void run(ProjectInspector inspector_in) {
+        GitRepositoryProjectInspector inspector = (GitRepositoryProjectInspector) inspector_in;
+        if (inspector.getGitRepositoryUrl() != null) {
+            AbstractStep cloneRepo = new CloneCheckoutBranchRepository(inspector);
+
+            cloneRepo.addNextStep(new BuildProject(inspector))
+                    .addNextStep(new TestProject(inspector))
+                    .addNextStep(new ComputeClasspath(inspector, false))
+                    .addNextStep(new ComputeSourceDir(inspector, false, false))
+                    .addNextStep(new ComputeTestDir(inspector, true))
+                    .addNextStep(new FlacocoLocalization(inspector, true));
+
+            PushFaultLocalizationSuggestions finalStep = new PushFaultLocalizationSuggestions(inspector, true);
+            cloneRepo.addNextStep(finalStep);
+            inspector.setFinalStep(finalStep);
+
+            inspector.printPipeline();
+
+            try {
+                cloneRepo.execute();
+            } catch (Exception e) {
+                inspector.getJobStatus().addStepError("Unknown", e.getMessage());
+                inspector.getLogger().error("Exception catch while executing steps: ", e);
+                inspector.getJobStatus().setFatalError(e);
+
+                ErrorNotifier errorNotifier = ErrorNotifier.getInstance();
+                if (errorNotifier != null) {
+                    errorNotifier.observe(inspector);
+                }
+
+                for (AbstractDataSerializer serializer : inspector.getSerializers()) {
+                    serializer.serialize();
+                }
+            }
+        } else {
+            inspector.getLogger().debug("Build " + inspector.getBuggyBuild().getId() + " is not a failing build.");
+        }
+    }
+}

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/components/RunInspector4FaultLocalization.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/inspectors/components/RunInspector4FaultLocalization.java
@@ -33,7 +33,6 @@ public class RunInspector4FaultLocalization extends IRunInspector {
                 .addNextStep(new FlacocoLocalization(inspector, true));
 
         PushFaultLocalizationSuggestions finalStep = new PushFaultLocalizationSuggestions(inspector, true);
-        cloneRepo.addNextStep(finalStep);
         inspector.setFinalStep(finalStep);
 
         inspector.printPipeline();

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/faultLocalization/FlacocoLocalization.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/faultLocalization/FlacocoLocalization.java
@@ -1,5 +1,6 @@
 package fr.inria.spirals.repairnator.process.step.faultLocalization;
 
+import fr.inria.spirals.repairnator.config.RepairnatorConfig;
 import fr.inria.spirals.repairnator.process.inspectors.JobStatus;
 import fr.inria.spirals.repairnator.process.inspectors.ProjectInspector;
 import fr.inria.spirals.repairnator.process.step.AbstractStep;
@@ -42,8 +43,7 @@ public class FlacocoLocalization extends AbstractStep {
         flacocoConfig.setProjectPath(jobStatus.getFailingModulePath());
         flacocoConfig.setClasspath(jobStatus.getRepairClassPath().stream()
                 .map(URL::getPath).reduce((x, y) -> x + File.pathSeparator + y).orElse(""));
-        flacocoConfig.setThreshold(0);
-        flacocoConfig.setIncludeZeros(true);
+        flacocoConfig.setThreshold(RepairnatorConfig.getInstance().getFlacocoThreshold());
     }
 
 }

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/faultLocalization/FlacocoLocalization.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/faultLocalization/FlacocoLocalization.java
@@ -1,0 +1,49 @@
+package fr.inria.spirals.repairnator.process.step.faultLocalization;
+
+import fr.inria.spirals.repairnator.process.inspectors.JobStatus;
+import fr.inria.spirals.repairnator.process.inspectors.ProjectInspector;
+import fr.inria.spirals.repairnator.process.step.AbstractStep;
+import fr.inria.spirals.repairnator.process.step.StepStatus;
+import fr.spoonlabs.flacoco.api.Flacoco;
+import fr.spoonlabs.flacoco.api.Suspiciousness;
+import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Map;
+
+public class FlacocoLocalization extends AbstractStep {
+
+    public FlacocoLocalization(ProjectInspector inspector, boolean blockingStep) {
+        super(inspector, blockingStep);
+    }
+
+    public FlacocoLocalization(ProjectInspector inspector, boolean blockingStep, String name) {
+        super(inspector, blockingStep, name);
+    }
+
+    @Override
+    protected StepStatus businessExecute() {
+        setupFlacocoConfig();
+
+        Flacoco flacoco = new Flacoco();
+        Map<String, Suspiciousness> results = flacoco.runDefault();
+
+        this.getLogger().debug("Results from flacoco: " + results.toString());
+
+        this.getInspector().getJobStatus().setFlacocoResults(results);
+        return StepStatus.buildSuccess(this);
+    }
+
+    private void setupFlacocoConfig() {
+        FlacocoConfig flacocoConfig = FlacocoConfig.getInstance();
+        JobStatus jobStatus = this.getInspector().getJobStatus();
+
+        flacocoConfig.setProjectPath(jobStatus.getFailingModulePath());
+        flacocoConfig.setClasspath(jobStatus.getRepairClassPath().stream()
+                .map(URL::getPath).reduce((x, y) -> x + File.pathSeparator + y).orElse(""));
+        flacocoConfig.setThreshold(0);
+        flacocoConfig.setIncludeZeros(true);
+    }
+
+}

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/faultLocalization/FlacocoLocalization.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/faultLocalization/FlacocoLocalization.java
@@ -6,12 +6,11 @@ import fr.inria.spirals.repairnator.process.inspectors.ProjectInspector;
 import fr.inria.spirals.repairnator.process.step.AbstractStep;
 import fr.inria.spirals.repairnator.process.step.StepStatus;
 import fr.spoonlabs.flacoco.api.Flacoco;
-import fr.spoonlabs.flacoco.api.Suspiciousness;
+import fr.spoonlabs.flacoco.api.result.FlacocoResult;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 
 import java.io.File;
 import java.net.URL;
-import java.util.Map;
 
 public class FlacocoLocalization extends AbstractStep {
 
@@ -28,11 +27,11 @@ public class FlacocoLocalization extends AbstractStep {
         setupFlacocoConfig();
 
         Flacoco flacoco = new Flacoco();
-        Map<String, Suspiciousness> results = flacoco.runDefault();
+        FlacocoResult result = flacoco.run();
 
-        this.getLogger().debug("Results from flacoco: " + results.toString());
+        this.getLogger().debug("Results from flacoco: " + result.getDefaultSuspiciousnessMap().toString());
 
-        this.getInspector().getJobStatus().setFlacocoResults(results);
+        this.getInspector().getJobStatus().setFlacocoResult(result);
         return StepStatus.buildSuccess(this);
     }
 

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/faultLocalization/FlacocoLocalization.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/faultLocalization/FlacocoLocalization.java
@@ -24,9 +24,8 @@ public class FlacocoLocalization extends AbstractStep {
 
     @Override
     protected StepStatus businessExecute() {
-        setupFlacocoConfig();
-
-        Flacoco flacoco = new Flacoco();
+        FlacocoConfig config = setupFlacocoConfig();
+        Flacoco flacoco = new Flacoco(config);
         FlacocoResult result = flacoco.run();
 
         this.getLogger().debug("Results from flacoco: " + result.getDefaultSuspiciousnessMap().toString());
@@ -35,14 +34,16 @@ public class FlacocoLocalization extends AbstractStep {
         return StepStatus.buildSuccess(this);
     }
 
-    private void setupFlacocoConfig() {
-        FlacocoConfig flacocoConfig = FlacocoConfig.getInstance();
+    private FlacocoConfig setupFlacocoConfig() {
+        FlacocoConfig flacocoConfig = new FlacocoConfig();
         JobStatus jobStatus = this.getInspector().getJobStatus();
 
         flacocoConfig.setProjectPath(jobStatus.getFailingModulePath());
         flacocoConfig.setClasspath(jobStatus.getRepairClassPath().stream()
                 .map(URL::getPath).reduce((x, y) -> x + File.pathSeparator + y).orElse(""));
         flacocoConfig.setThreshold(RepairnatorConfig.getInstance().getFlacocoThreshold());
+
+        return flacocoConfig;
     }
 
 }

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/push/PushFaultLocalizationSuggestions.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/push/PushFaultLocalizationSuggestions.java
@@ -27,6 +27,11 @@ public class PushFaultLocalizationSuggestions extends AbstractStep {
 
     @Override
     protected StepStatus businessExecute() {
+        if (!this.getInspector().getBuggyBuild().isPullRequest()) {
+            this.getLogger().warn("Fault localization suggestions are not available outside pull requests");
+            return StepStatus.buildSkipped(this, "Fault localization suggestions are not available outside pull requests.");
+        }
+
         try {
             pushReviewComments(this.getInspector().getJobStatus().getFlacocoResults());
         } catch (IOException e) {
@@ -41,7 +46,7 @@ public class PushFaultLocalizationSuggestions extends AbstractStep {
     private void pushReviewComments(Map<String, Suspiciousness> results) throws IOException {
         GitHub gitHub = GitHub.connectUsingOAuth(RepairnatorConfig.getInstance().getGithubToken());
         GHRepository originalRepository = gitHub.getRepository(this.getInspector().getRepoSlug());
-        GHPullRequest pullRequest = originalRepository.getPullRequest(2);
+        GHPullRequest pullRequest = originalRepository.getPullRequest(this.getInspector().getBuggyBuild().getPullRequestNumber());
         Map<String, Map<Integer, Integer>> diffMapping = computeDiffMapping(pullRequest.getDiffUrl());
         GHPullRequestReviewBuilder reviewBuilder = pullRequest.createReview();
 

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/push/PushFaultLocalizationSuggestions.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/push/PushFaultLocalizationSuggestions.java
@@ -43,7 +43,7 @@ public class PushFaultLocalizationSuggestions extends AbstractStep {
     }
 
     private void pushReviewComments(Map<String, Suspiciousness> results) throws IOException {
-        GitHub gitHub = GitHub.connectUsingOAuth(RepairnatorConfig.getInstance().getGithubToken());
+        GitHub gitHub = RepairnatorConfig.getInstance().getGithub();
         GHRepository originalRepository = gitHub.getRepository(this.getInspector().getRepoSlug());
         GHPullRequest pullRequest = originalRepository.getPullRequest(this.getInspector().getBuggyBuild().getPullRequestNumber());
         Map<String, Map<Integer, Integer>> diffMapping = computeDiffMapping(pullRequest.getDiffUrl());

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/push/PushFaultLocalizationSuggestions.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/push/PushFaultLocalizationSuggestions.java
@@ -40,7 +40,6 @@ public class PushFaultLocalizationSuggestions extends AbstractStep {
         }
 
         return StepStatus.buildSuccess(this);
-
     }
 
     private void pushReviewComments(Map<String, Suspiciousness> results) throws IOException {

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/push/PushFaultLocalizationSuggestions.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/push/PushFaultLocalizationSuggestions.java
@@ -1,0 +1,152 @@
+package fr.inria.spirals.repairnator.process.step.push;
+
+import fr.inria.spirals.repairnator.config.RepairnatorConfig;
+import fr.inria.spirals.repairnator.process.inspectors.ProjectInspector;
+import fr.inria.spirals.repairnator.process.step.AbstractStep;
+import fr.inria.spirals.repairnator.process.step.StepStatus;
+import fr.spoonlabs.flacoco.api.Suspiciousness;
+import org.kohsuke.github.*;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PushFaultLocalizationSuggestions extends AbstractStep {
+
+    public PushFaultLocalizationSuggestions(ProjectInspector inspector, boolean blockingStep) {
+        super(inspector, blockingStep);
+    }
+
+    public PushFaultLocalizationSuggestions(ProjectInspector inspector, boolean blockingStep, String name) {
+        super(inspector, blockingStep, name);
+    }
+
+    @Override
+    protected StepStatus businessExecute() {
+        try {
+            pushReviewComments(this.getInspector().getJobStatus().getFlacocoResults());
+        } catch (IOException e) {
+            this.getLogger().error(e.getLocalizedMessage());
+            return StepStatus.buildSkipped(this, "There was an error while publishing fault localization results: " + e);
+        }
+
+        return StepStatus.buildSuccess(this);
+
+    }
+
+    private void pushReviewComments(Map<String, Suspiciousness> results) throws IOException {
+        GitHub gitHub = GitHub.connectUsingOAuth(RepairnatorConfig.getInstance().getGithubToken());
+        GHRepository originalRepository = gitHub.getRepository(this.getInspector().getRepoSlug());
+        GHPullRequest pullRequest = originalRepository.getPullRequest(2);
+        Map<String, Map<Integer, Integer>> diffMapping = computeDiffMapping(pullRequest.getDiffUrl());
+        GHPullRequestReviewBuilder reviewBuilder = pullRequest.createReview();
+
+        int lines = 0;
+        for (Map.Entry<String, Suspiciousness> entry : results.entrySet()) {
+            String partialFileName = entry.getKey().split("@-@")[0];
+            Integer line = Integer.parseInt(entry.getKey().split("@-@")[1]);
+
+            for (String fileName : diffMapping.keySet()) {
+
+                // Since we don't have an exact mapping, we need to partially match them
+                if (fileName.contains(partialFileName)) {
+
+                    // We only consider the lines that are in the diff (i.e. that are mapped to a position in the diffMapping)
+                    if (diffMapping.get(fileName).containsKey(line)) {
+                        lines++;
+                        reviewBuilder.comment(
+                                String.format(
+                                        "This line (%d) has been identified with a suspiciousness value of %,.2f%%.\n" +
+                                                "The following failing tests covered this line: " +
+                                                entry.getValue().getFailingTestCases().stream()
+                                                        .map(x -> "`" + x.getFullyQualifiedMethodName() + "`")
+                                                        .reduce((x, y) -> x + "," + y).orElse("{}"),
+                                        line, entry.getValue().getScore() * 100),
+                                fileName,
+                                diffMapping.get(fileName).get(line)
+                        );
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        if (lines > 0) {
+            reviewBuilder.body("[flacoco](https://github.com/SpoonLabs/flacoco) has found " + lines + " suspicious lines in the diff:");
+            reviewBuilder.event(GHPullRequestReviewEvent.COMMENT);
+            reviewBuilder.create();
+        } else {
+            this.getLogger().warn("Flacoco has found " + results.size() + " suspicious lines, but none were matched to the diff");
+        }
+    }
+
+    /**
+     * Computes the mapping between source code lines and diff positions
+     *
+     * @param diffUrl URL to the diff
+     * @return A mapping from file path to a mapping from source code lines to diff positions
+     * @throws IOException
+     */
+    private Map<String, Map<Integer, Integer>> computeDiffMapping(URL diffUrl) throws IOException {
+        Scanner scanner = new Scanner(diffUrl.openStream(), "UTF-8");
+        scanner.useDelimiter("\\n");
+
+        Map<String, Map<Integer, Integer>> diffMapping = new HashMap<>();
+        String currentFile = null;
+        Integer currentPosition = null;
+        Integer currentLine = null;
+        while (scanner.hasNext()) {
+            String line = scanner.next();
+
+            // We don't need the information from these lines
+            if (line.startsWith("diff --git") || line.startsWith("index") || line.startsWith("---"))
+                continue;
+
+            // We get the file name, so we reset the position and null the line
+            if (line.startsWith("+++")) {
+                currentFile = line.replace("+++ b/", "");
+                currentPosition = 0;
+                currentLine = null;
+            }
+
+            // Marks the beggining of a new hunk
+            // e.g.: @@ -29,4 +30,4
+            // in this case, the line where the hunk starts is the 29th (we consider the new file version)
+            else if (line.startsWith("@@")) {
+                Pattern p = Pattern.compile("@@ .*?\\-(\\d+),?(\\d+)?.*?\\+(\\d+),?(\\d+)? @@.*$?");
+                Matcher matcher = p.matcher(line);
+                currentPosition = currentPosition != 0 ? currentPosition + 1 : currentPosition;
+                if (matcher.matches())
+                    currentLine = Integer.parseInt(matcher.group(3)) - 1;
+            }
+
+            // In this case we increment the position but don't store any mapping as we only care about the new file
+            else if (line.startsWith("-") || line.startsWith("\\")) {
+                currentPosition += 1;
+                continue;
+            }
+
+            // In this case we increment both the position and line, since we have advanced one line in the hunk
+            else {
+                currentPosition += 1;
+                currentLine += 1;
+            }
+
+            // We record the mapping for the current file, between the line and position
+            if (currentFile != null && currentPosition != null && currentLine != null) {
+                diffMapping.putIfAbsent(currentFile, new HashMap<>());
+                diffMapping.get(currentFile).put(currentLine, currentPosition);
+            }
+        }
+
+        scanner.close();
+
+        return diffMapping;
+    }
+
+}

--- a/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/soraldbot/SoraldBot.java
+++ b/src/repairnator-pipeline/src/main/java/fr/inria/spirals/repairnator/process/step/repair/soraldbot/SoraldBot.java
@@ -22,7 +22,6 @@ import org.eclipse.jgit.treewalk.CanonicalTreeParser;
 import org.kohsuke.github.GHBranch;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
-import org.kohsuke.github.GitHubBuilder;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -53,7 +52,7 @@ public class SoraldBot extends AbstractRepairStep {
         try {
             originalBranchName = getOriginalBranch();
         } catch (IOException e) {
-            getLogger().error("IOException while looking for the original branch");
+            getLogger().error("IOException while looking for the original branch: " + e.getLocalizedMessage());
         }
 
         return commit != null && workingRepoPath != null && originalBranchName != null;
@@ -127,7 +126,7 @@ public class SoraldBot extends AbstractRepairStep {
     }
 
     private String getOriginalBranch() throws IOException {
-        GitHub github = new GitHubBuilder().withOAuthToken(RepairnatorConfig.getInstance().getGithubToken()).build();
+        GitHub github = RepairnatorConfig.getInstance().getGithub();
         GHRepository repo = github.getRepository(getInspector().getRepoSlug());
         Map<String, GHBranch> branches = repo.getBranches();
         Optional<String> branch = branches

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineFaultLocalization.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineFaultLocalization.java
@@ -1,0 +1,57 @@
+package fr.inria.spirals.repairnator.pipeline;
+
+import fr.inria.spirals.repairnator.config.RepairnatorConfig;
+import fr.inria.spirals.repairnator.process.step.AbstractStep;
+import fr.inria.spirals.repairnator.process.step.faultLocalization.FlacocoLocalization;
+import fr.inria.spirals.repairnator.process.step.push.PushFaultLocalizationSuggestions;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class TestPipelineFaultLocalization {
+
+    @Rule
+    public TemporaryFolder workspaceFolder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryFolder outputFolder = new TemporaryFolder();
+
+    @After
+    public void tearDown() throws IOException {
+        RepairnatorConfig.deleteInstance();
+    }
+
+    /**
+     * No results are pushed because the default threshold is higher than any of the lines executed
+     * inside the actual diff. This is meant to be, since we cannot test this feature in CI easily.
+     * @throws Exception
+     */
+    @Test
+    public void testPipelineFaultLocalization() throws Exception {
+        Launcher launcher = new Launcher(new String[]{
+                "--build", "235987498",
+                "--faultLocalization",
+                "--launcherMode", "FAULT_LOCALIZATION",
+                "--workspace", workspaceFolder.getRoot().getAbsolutePath(),
+                "--output", outputFolder.getRoot().getAbsolutePath()
+        });
+
+        launcher.mainProcess();
+
+        // we check that the pipeline has been built for fault localization
+        List<AbstractStep> steps = launcher.getInspector().getSteps();
+
+        assertThat(steps.size(), is(10));
+        assertThat(steps.get(8), instanceOf(FlacocoLocalization.class));
+        assertThat(steps.get(9), instanceOf(PushFaultLocalizationSuggestions.class));
+    }
+
+}

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineFaultLocalization.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/pipeline/TestPipelineFaultLocalization.java
@@ -37,7 +37,8 @@ public class TestPipelineFaultLocalization {
     @Test
     public void testPipelineFaultLocalization() throws Exception {
         Launcher launcher = new Launcher(new String[]{
-                "--build", "235987498",
+                "--build", "236072272",
+                "--flacocoThreshold", "1.0", // This threshold results in 0 lines, and so the result is not pushed
                 "--faultLocalization",
                 "--launcherMode", "FAULT_LOCALIZATION",
                 "--workspace", workspaceFolder.getRoot().getAbsolutePath(),

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/faultLocalization/TestFlacocoLocalization.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/faultLocalization/TestFlacocoLocalization.java
@@ -1,0 +1,111 @@
+package fr.inria.spirals.repairnator.process.step.faultLocalization;
+
+import ch.qos.logback.classic.Level;
+import fr.inria.jtravis.entities.Build;
+import fr.inria.spirals.repairnator.BuildToBeInspected;
+import fr.inria.spirals.repairnator.config.RepairnatorConfig;
+import fr.inria.spirals.repairnator.process.inspectors.ProjectInspector;
+import fr.inria.spirals.repairnator.process.step.CloneRepository;
+import fr.inria.spirals.repairnator.process.step.StepStatus;
+import fr.inria.spirals.repairnator.process.step.TestProject;
+import fr.inria.spirals.repairnator.process.step.checkoutrepository.CheckoutBuggyBuild;
+import fr.inria.spirals.repairnator.process.step.gatherinfo.BuildShouldFail;
+import fr.inria.spirals.repairnator.process.step.gatherinfo.GatherTestInformation;
+import fr.inria.spirals.repairnator.process.step.paths.ComputeClasspath;
+import fr.inria.spirals.repairnator.process.step.paths.ComputeSourceDir;
+import fr.inria.spirals.repairnator.process.step.paths.ComputeTestDir;
+import fr.inria.spirals.repairnator.states.ScannedBuildStatus;
+import fr.inria.spirals.repairnator.utils.Utils;
+import fr.spoonlabs.flacoco.api.Suspiciousness;
+import org.hamcrest.core.Is;
+import org.hamcrest.core.IsNull;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class TestFlacocoLocalization {
+
+    @Rule
+    public TemporaryFolder workspaceFolder = new TemporaryFolder();
+
+    @Before
+    public void setup() {
+        Utils.setLoggersLevel(Level.ERROR);
+        RepairnatorConfig config = RepairnatorConfig.getInstance();
+        config.setJTravisEndpoint("https://api.travis-ci.com");
+        config.setFlacocoThreshold(0.5);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        RepairnatorConfig.deleteInstance();
+    }
+
+    @Test
+    public void testFlacocoLocalization() throws IOException {
+        long buildId = 235987498; // repairnator/failingProject build
+
+        Build build = this.checkBuildAndReturn(buildId, true);
+
+        BuildToBeInspected toBeInspected = new BuildToBeInspected(build, null, ScannedBuildStatus.ONLY_FAIL, "");
+
+        ProjectInspector inspector = new ProjectInspector(toBeInspected, workspaceFolder.getRoot().getAbsolutePath(), null, null);
+
+        CloneRepository cloneStep = new CloneRepository(inspector);
+        FlacocoLocalization flacocoLocalization = new FlacocoLocalization(inspector, true);
+
+        cloneStep.addNextStep(new CheckoutBuggyBuild(inspector, true))
+                .addNextStep(new TestProject(inspector))
+                .addNextStep(new GatherTestInformation(inspector, true, new BuildShouldFail(), false))
+                .addNextStep(new ComputeClasspath(inspector, true))
+                .addNextStep(new ComputeSourceDir(inspector, true, false))
+                .addNextStep(new ComputeTestDir(inspector, true))
+                .addNextStep(flacocoLocalization);
+        cloneStep.execute();
+
+        assertThat(flacocoLocalization.isShouldStop(), is(false));
+
+        List<StepStatus> stepStatusList = inspector.getJobStatus().getStepStatuses();
+        assertThat(stepStatusList.size(), is(8));
+        StepStatus assertFixerStatus = stepStatusList.get(7);
+        assertThat(assertFixerStatus.getStep(), is(flacocoLocalization));
+
+        for (StepStatus stepStatus : stepStatusList) {
+            assertThat("Failing step :" + stepStatus, stepStatus.isSuccess(), is(true));
+        }
+
+        // assert that fault localization results are stored
+        Map<String, Suspiciousness> results = inspector.getJobStatus().getFlacocoResults();
+        assertThat(results, notNullValue());
+        assertThat(results.size(), is(3));
+
+        assertThat(results.get("nopol_examples/nopol_example_3/NopolExample@-@3"), notNullValue());
+        assertThat(results.get("nopol_examples/nopol_example_3/NopolExample@-@9"), notNullValue());
+        assertThat(results.get("nopol_examples/nopol_example_3/NopolExample@-@11"), notNullValue());
+    }
+
+    private Build checkBuildAndReturn(long buildId, boolean isPR) {
+        Optional<Build> optionalBuild = RepairnatorConfig.getInstance().getJTravis().build().fromId(buildId);
+        assertTrue(optionalBuild.isPresent());
+
+        Build build = optionalBuild.get();
+        assertThat(build, IsNull.notNullValue());
+        assertThat(buildId, Is.is(build.getId()));
+        assertThat(build.isPullRequest(), Is.is(isPR));
+
+        return build;
+    }
+
+}

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/faultLocalization/TestFlacocoLocalization.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/faultLocalization/TestFlacocoLocalization.java
@@ -16,7 +16,8 @@ import fr.inria.spirals.repairnator.process.step.paths.ComputeSourceDir;
 import fr.inria.spirals.repairnator.process.step.paths.ComputeTestDir;
 import fr.inria.spirals.repairnator.states.ScannedBuildStatus;
 import fr.inria.spirals.repairnator.utils.Utils;
-import fr.spoonlabs.flacoco.api.Suspiciousness;
+import fr.spoonlabs.flacoco.api.result.Location;
+import fr.spoonlabs.flacoco.api.result.Suspiciousness;
 import org.hamcrest.core.Is;
 import org.hamcrest.core.IsNull;
 import org.junit.After;
@@ -87,14 +88,14 @@ public class TestFlacocoLocalization {
         }
 
         // assert that fault localization results are stored
-        Map<String, Suspiciousness> results = inspector.getJobStatus().getFlacocoResults();
+        Map<Location, Suspiciousness> results = inspector.getJobStatus().getFlacocoResult().getDefaultSuspiciousnessMap();
         assertThat(results, notNullValue());
         assertThat(results.size(), is(4));
 
-        assertThat(results.get("nopol_examples/nopol_example_3/NopolExample@-@3"), notNullValue());
-        assertThat(results.get("nopol_examples/nopol_example_3/NopolExample@-@9"), notNullValue());
-        assertThat(results.get("nopol_examples/nopol_example_3/NopolExample@-@10"), notNullValue());
-        assertThat(results.get("nopol_examples/nopol_example_3/NopolExample@-@12"), notNullValue());
+        assertThat(results.get(new Location("nopol_examples.nopol_example_3.NopolExample", 3)), notNullValue());
+        assertThat(results.get(new Location("nopol_examples.nopol_example_3.NopolExample", 9)), notNullValue());
+        assertThat(results.get(new Location("nopol_examples.nopol_example_3.NopolExample", 10)), notNullValue());
+        assertThat(results.get(new Location("nopol_examples.nopol_example_3.NopolExample", 12)), notNullValue());
     }
 
     private Build checkBuildAndReturn(long buildId, boolean isPR) {

--- a/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/faultLocalization/TestFlacocoLocalization.java
+++ b/src/repairnator-pipeline/src/test/java/fr/inria/spirals/repairnator/process/step/faultLocalization/TestFlacocoLocalization.java
@@ -55,7 +55,7 @@ public class TestFlacocoLocalization {
 
     @Test
     public void testFlacocoLocalization() throws IOException {
-        long buildId = 235987498; // repairnator/failingProject build
+        long buildId = 236072272; // repairnator/failingProject build
 
         Build build = this.checkBuildAndReturn(buildId, true);
 
@@ -89,11 +89,12 @@ public class TestFlacocoLocalization {
         // assert that fault localization results are stored
         Map<String, Suspiciousness> results = inspector.getJobStatus().getFlacocoResults();
         assertThat(results, notNullValue());
-        assertThat(results.size(), is(3));
+        assertThat(results.size(), is(4));
 
         assertThat(results.get("nopol_examples/nopol_example_3/NopolExample@-@3"), notNullValue());
         assertThat(results.get("nopol_examples/nopol_example_3/NopolExample@-@9"), notNullValue());
-        assertThat(results.get("nopol_examples/nopol_example_3/NopolExample@-@11"), notNullValue());
+        assertThat(results.get("nopol_examples/nopol_example_3/NopolExample@-@10"), notNullValue());
+        assertThat(results.get("nopol_examples/nopol_example_3/NopolExample@-@12"), notNullValue());
     }
 
     private Build checkBuildAndReturn(long buildId, boolean isPR) {

--- a/src/repairnator-realtime/pom.xml
+++ b/src/repairnator-realtime/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.130</version>
+            <version>1.132</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Repairnator is now able to export fault localization results to a PR review. (See https://github.com/repairnator/failingProject/pull/6).

```bash
java -cp target/repairnator-pipeline-3.3-SNAPSHOT-jar-with-dependencies.jar fr.inria.spirals.repairnator.pipeline.Launcher --launcherMode FAULT_LOCALIZATION --faultLocalization --build 235987498 --ghOauth $GITHUB_TOKEN
```

Opening this draft PR to make sure CI is still working.

TODO:
- [x] Add options for configuring flacoco
- [x] Add tests
- [x] Add documentation

Closes #1116
Closes #1029